### PR TITLE
Fix Show instances to respect precedence

### DIFF
--- a/fixed-vector/Data/Vector/Fixed/Boxed.hs
+++ b/fixed-vector/Data/Vector/Fixed/Boxed.hs
@@ -36,7 +36,8 @@ import Prelude ( Show(..),Eq(..),Ord(..),Functor(..),Monad(..)
 
 import Data.Vector.Fixed hiding (index)
 import Data.Vector.Fixed.Mutable
-import qualified Data.Vector.Fixed.Cont as C
+import qualified Data.Vector.Fixed.Cont     as C
+import qualified Data.Vector.Fixed.Internal as I
 
 
 
@@ -90,7 +91,7 @@ instance (Storable a, Arity n) => Storable (Vec n a) where
 ----------------------------------------------------------------
 
 instance (Arity n, Show a) => Show (Vec n a) where
-  show v = "fromList " ++ show (toList v)
+  showsPrec = I.showsPrec
 
 instance (Arity n, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()

--- a/fixed-vector/Data/Vector/Fixed/Internal.hs
+++ b/fixed-vector/Data/Vector/Fixed/Internal.hs
@@ -104,7 +104,7 @@ replicate
 --
 --   >>> import Data.Vector.Fixed.Boxed (Vec2,Vec3)
 --   >>> replicateM (Just 3) :: Maybe (Vec3 Int)
---   Just fromList [3,3,3]
+--   Just (fromList [3,3,3])
 --   >>> replicateM (putStrLn "Hi!") :: IO (Vec2 ())
 --   Hi!
 --   Hi!
@@ -661,3 +661,8 @@ fromListM = fmap vector . C.fromListM
 fromFoldable :: (Vector v a, T.Foldable f) => f a -> Maybe (v a)
 {-# INLINE fromFoldable #-}
 fromFoldable = fromListM . T.toList
+
+-- | Generic definition of 'Prelude.showsPrec'
+showsPrec :: (Vector v a, Show a) => Int -> v a -> ShowS
+showsPrec d v = showParen (d > 10) $ showString "fromList " . Prelude.showsPrec 11 (toList v)
+{-# INLINE showsPrec #-}

--- a/fixed-vector/Data/Vector/Fixed/Primitive.hs
+++ b/fixed-vector/Data/Vector/Fixed/Primitive.hs
@@ -40,7 +40,8 @@ import Prelude ((++),($),($!),undefined,seq)
 
 import Data.Vector.Fixed hiding (index)
 import Data.Vector.Fixed.Mutable
-import qualified Data.Vector.Fixed.Cont as C
+import qualified Data.Vector.Fixed.Cont     as C
+import qualified Data.Vector.Fixed.Internal as I
 
 
 
@@ -70,7 +71,7 @@ type Vec5 = Vec 5
 ----------------------------------------------------------------
 
 instance (Arity n, Prim a, Show a) => Show (Vec n a) where
-  show v = "fromList " ++ show (toList v)
+  showsPrec = I.showsPrec
 
 instance (Arity n, Prim a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()

--- a/fixed-vector/Data/Vector/Fixed/Storable.hs
+++ b/fixed-vector/Data/Vector/Fixed/Storable.hs
@@ -44,7 +44,8 @@ import Prelude ( Show(..),Eq(..),Ord(..),Num(..),Monad(..),IO,Int
 
 import Data.Vector.Fixed hiding (index)
 import Data.Vector.Fixed.Mutable
-import qualified Data.Vector.Fixed.Cont as C
+import qualified Data.Vector.Fixed.Cont     as C
+import qualified Data.Vector.Fixed.Internal as I
 
 
 
@@ -94,7 +95,7 @@ unsafeWith f (Vec fp) = f (getPtr fp)
 ----------------------------------------------------------------
 
 instance (Arity n, Storable a, Show a) => Show (Vec n a) where
-  show v = "fromList " ++ show (toList v)
+  showsPrec = I.showsPrec
 
 instance (Arity n, Storable a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()

--- a/fixed-vector/Data/Vector/Fixed/Unboxed.hs
+++ b/fixed-vector/Data/Vector/Fixed/Unboxed.hs
@@ -41,12 +41,13 @@ import GHC.TypeLits
 import Prelude               ( Show(..),Eq(..),Ord(..),Int,Double,Float,Char,Bool(..)
                              , (++),($),(.),seq)
 
-import Data.Vector.Fixed (Dim,Vector(..),VectorN,toList,eq,ord,replicate,zipWith,foldl,
+import Data.Vector.Fixed (Dim,Vector(..),VectorN,eq,ord,replicate,zipWith,foldl,
                           defaultSizeOf,defaultAlignemnt,defaultPeek,defaultPoke
                          )
 import Data.Vector.Fixed.Mutable
 import qualified Data.Vector.Fixed.Cont      as C
 import qualified Data.Vector.Fixed.Primitive as P
+import qualified Data.Vector.Fixed.Internal  as I
 
 
 
@@ -74,7 +75,7 @@ class (Arity n, IVector (Vec n) a, MVector (MVec n) a) => Unbox n a
 ----------------------------------------------------------------
 
 instance (Arity n, Show a, Unbox n a) => Show (Vec n a) where
-  show v = "fromList " ++ show (toList v)
+  showsPrec = I.showsPrec
 
 instance (Arity n, Unbox n a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()


### PR DESCRIPTION
Now something like `Just (fromList [3,3,3])` shows as expected. Also updated the doctest.