### PR TITLE
Implement Dim in terms of Peano numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
       matrix:
         include:
           # Linux
-          - { cabal: "3.12", os: ubuntu-latest,  ghc: "8.4.4"  }
-          - { cabal: "3.12", os: ubuntu-latest,  ghc: "8.6.5"  }
-          - { cabal: "3.12", os: ubuntu-latest,  ghc: "8.8.4"  }
           - { cabal: "3.12", os: ubuntu-latest,  ghc: "8.10.7" }
           - { cabal: "3.12", os: ubuntu-latest,  ghc: "9.0.1"  }
           - { cabal: "3.12", os: ubuntu-latest,  ghc: "9.2.8"  }

--- a/fixed-vector-cborg/Data/Vector/Fixed/Instances/CBOR.hs
+++ b/fixed-vector-cborg/Data/Vector/Fixed/Instances/CBOR.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE MagicHash            #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -10,12 +12,11 @@ module Data.Vector.Fixed.Instances.CBOR where
 import           Codec.Serialise
 import           Codec.CBOR.Encoding           (Encoding,encodeListLen,encodeNull)
 import           Codec.CBOR.Decoding           (Decoder,decodeListLenOf,decodeNull)
-import           Data.Monoid                   ((<>))
-import           Data.Typeable                 (Proxy(..))
+import           GHC.Exts                      (proxy#)
 
 import           Data.Vector.Fixed             (Arity)
 import qualified Data.Vector.Fixed           as F
-import           Data.Vector.Fixed.Cont        (arity,Dim)
+import           Data.Vector.Fixed.Cont        (peanoToInt,Dim)
 import qualified Data.Vector.Fixed.Boxed     as B
 import qualified Data.Vector.Fixed.Unboxed   as U
 import qualified Data.Vector.Fixed.Primitive as P
@@ -63,5 +64,5 @@ encodeFixedVector v = encodeListLen (fromIntegral $ F.length v)
 decodeFixedVector :: forall v s a. (F.Vector v a, Serialise a) => Decoder s (v a)
 {-# INLINE decodeFixedVector #-}
 decodeFixedVector = do
-  decodeListLenOf (fromIntegral $ arity (Proxy :: Proxy (Dim v)))
+  decodeListLenOf (fromIntegral $ peanoToInt (proxy# @(Dim v)))
   F.replicateM decode

--- a/fixed-vector/ChangeLog.md
+++ b/fixed-vector/ChangeLog.md
@@ -1,3 +1,18 @@
+Changes in 1.3.0.0
+
+  * Type family `Dim` returns Peano numbers instead of standard type level
+    naturals.
+
+     - `Index` type class restored and all indexing operation are performed in
+
+	 - `Arity` simplified
+
+	 - `CVecPeano` dropped and `ContVec` is parameterized using Peano numbers.
+
+  * `Data.Vector.Fixed.Cont.arity` dropped
+
+  * Type of `D.V.F.Cont.withFun` generalized
+
 Changes in 1.2.3.0
 
   * Pattern `V1` added

--- a/fixed-vector/ChangeLog.md
+++ b/fixed-vector/ChangeLog.md
@@ -13,6 +13,8 @@ Changes in 1.3.0.0
 
   * Type of `D.V.F.Cont.withFun` generalized
 
+  * Type class `VectorN` dropped. Use QuantifiedConstraints instead
+
 Changes in 1.2.3.0
 
   * Pattern `V1` added

--- a/fixed-vector/Data/Vector/Fixed.hs
+++ b/fixed-vector/Data/Vector/Fixed.hs
@@ -245,13 +245,13 @@ data VecPeano (n :: PeanoNum) a where
   Cons :: a -> VecPeano n a -> VecPeano ('S n) a
   deriving (Typeable)
 
-instance (Arity (C.Peano n), NFData a) => NFData (VecList n a) where
+instance (Arity n, NFData a) => NFData (VecList n a) where
   rnf = defaultRnf
   {-# INLINE rnf #-}
 
 type instance Dim (VecList n) = C.Peano n
 
-instance Arity (C.Peano n) => Vector (VecList n) a where
+instance Arity n => Vector (VecList n) a where
   construct = fmap VecList $ accum
     (\(T_List f) a -> T_List (f . Cons a))
     (\(T_List f)   -> f Nil)
@@ -272,34 +272,34 @@ newtype T_List a n k = T_List (VecPeano k a -> VecPeano n a)
 
 
 -- Standard instances
-instance (Show a, Arity (C.Peano n)) => Show (VecList n a) where
+instance (Show a, Arity n) => Show (VecList n a) where
   show = show . foldr (:) []
-instance (Eq a, Arity (C.Peano n)) => Eq (VecList n a) where
+instance (Eq a, Arity n) => Eq (VecList n a) where
   (==) = eq
-instance (Ord a, Arity (C.Peano n)) => Ord (VecList n a) where
+instance (Ord a, Arity n) => Ord (VecList n a) where
   compare = ord
-instance Arity (C.Peano n) => Functor (VecList n) where
+instance Arity n => Functor (VecList n) where
   fmap = map
-instance Arity (C.Peano n) => Applicative (VecList n) where
+instance Arity n => Applicative (VecList n) where
   pure  = replicate
   (<*>) = zipWith ($)
-instance Arity (C.Peano n) => F.Foldable (VecList n) where
+instance Arity n => F.Foldable (VecList n) where
   foldr = foldr
-instance Arity (C.Peano n) => T.Traversable (VecList n) where
+instance Arity n => T.Traversable (VecList n) where
   sequenceA = sequenceA
   traverse  = traverse
-instance (Arity (C.Peano n), Monoid a) => Monoid (VecList n a) where
+instance (Arity n, Monoid a) => Monoid (VecList n a) where
   mempty  = replicate mempty
   mappend = (<>)
   {-# INLINE mempty  #-}
   {-# INLINE mappend #-}
 
-instance (Arity (C.Peano n), Semigroup a) => Semigroup (VecList n a) where
+instance (Arity n, Semigroup a) => Semigroup (VecList n a) where
   (<>) = zipWith (<>)
   {-# INLINE (<>) #-}
 
 
-instance (Storable a, Arity (C.Peano n)) => Storable (VecList n a) where
+instance (Storable a, Arity n) => Storable (VecList n a) where
   alignment = defaultAlignemnt
   sizeOf    = defaultSizeOf
   peek      = defaultPeek

--- a/fixed-vector/Data/Vector/Fixed.hs
+++ b/fixed-vector/Data/Vector/Fixed.hs
@@ -91,15 +91,15 @@ module Data.Vector.Fixed (
   , tail
   , cons
   , snoc
-  -- , concat   FIXME
+  , concat
   , reverse
     -- ** Indexing & lenses
   -- , C.Index
   , (!)
-  -- , index FIXME
-  -- , set  FIXME
+  , index
+  , set
   , element
-  -- , elementTy FIXME
+  , elementTy
     -- ** Comparison
   , eq
   , ord

--- a/fixed-vector/Data/Vector/Fixed.hs
+++ b/fixed-vector/Data/Vector/Fixed.hs
@@ -264,8 +264,7 @@ instance Arity n => Vector (VecList n) a where
   {-# INLINE construct #-}
   {-# INLINE inspect   #-}
 
--- FIXME
--- instance Arity n => VectorN VecList n a
+instance Arity n => VectorN VecList n a
 
 newtype Flip f a n = Flip (f n a)
 newtype T_List a n k = T_List (VecPeano k a -> VecPeano n a)

--- a/fixed-vector/Data/Vector/Fixed.hs
+++ b/fixed-vector/Data/Vector/Fixed.hs
@@ -50,7 +50,6 @@ module Data.Vector.Fixed (
     Dim
     -- ** Type class
   , Vector(..)
-  , VectorN
   , Arity
   , Fun(..)
   , length
@@ -186,7 +185,7 @@ import Foreign.Storable (Storable(..))
 import Foreign.Ptr      (castPtr)
 import GHC.TypeLits
 
-import Data.Vector.Fixed.Cont     (Vector(..),VectorN,Dim,length,ContVec,PeanoNum(..),
+import Data.Vector.Fixed.Cont     (Vector(..),Dim,length,ContVec,PeanoNum(..),
                                    vector,empty,Arity,Fun(..),accum,apply,vector)
 import qualified Data.Vector.Fixed.Cont as C
 import Data.Vector.Fixed.Internal
@@ -263,8 +262,6 @@ instance Arity n => Vector (VecList n) a where
       step (Flip (Cons a xs)) = (a, Flip xs)
   {-# INLINE construct #-}
   {-# INLINE inspect   #-}
-
-instance Arity n => VectorN VecList n a
 
 newtype Flip f a n = Flip (f n a)
 newtype T_List a n k = T_List (VecPeano k a -> VecPeano n a)

--- a/fixed-vector/Data/Vector/Fixed/Boxed.hs
+++ b/fixed-vector/Data/Vector/Fixed/Boxed.hs
@@ -137,7 +137,6 @@ instance (Arity n) => Vector (Vec n) a where
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-instance (Arity n) => VectorN Vec n a
 
 instance (Arity n, Eq a) => Eq (Vec n a) where
   (==) = eq

--- a/fixed-vector/Data/Vector/Fixed/Boxed.hs
+++ b/fixed-vector/Data/Vector/Fixed/Boxed.hs
@@ -40,7 +40,7 @@ import Prelude ( Show(..),Eq(..),Ord(..),Functor(..),Monad(..)
 import Data.Vector.Fixed hiding (index)
 import Data.Vector.Fixed.Mutable (Mutable, MVector(..), IVector(..), DimM, constructVec, inspectVec, index)
 import qualified Data.Vector.Fixed.Cont     as C
-import           Data.Vector.Fixed.Cont     (Peano,Arity(..))
+import           Data.Vector.Fixed.Cont     (Peano,ArityPeano(..))
 import qualified Data.Vector.Fixed.Internal as I
 
 
@@ -65,7 +65,7 @@ type Vec4 = Vec 4
 type Vec5 = Vec 5
 
 
-instance (Typeable n, Arity (Peano n), Data a) => Data (Vec n a) where
+instance (Typeable n, Arity n, Data a) => Data (Vec n a) where
   gfoldl       = C.gfoldl
   gunfold      = C.gunfold
   toConstr   _ = con_Vec
@@ -77,7 +77,7 @@ ty_Vec  = mkDataType "Data.Vector.Fixed.Boxed.Vec" [con_Vec]
 con_Vec :: Constr
 con_Vec = mkConstr ty_Vec "Vec" [] Prefix
 
-instance (Storable a, Arity (Peano n)) => Storable (Vec n a) where
+instance (Storable a, Arity n) => Storable (Vec n a) where
   alignment = defaultAlignemnt
   sizeOf    = defaultSizeOf
   peek      = defaultPeek
@@ -94,16 +94,16 @@ instance (Storable a, Arity (Peano n)) => Storable (Vec n a) where
 -- Instances
 ----------------------------------------------------------------
 
-instance (Arity (Peano n), Show a) => Show (Vec n a) where
+instance (Arity n, Show a) => Show (Vec n a) where
   showsPrec = I.showsPrec
 
-instance (Arity (Peano n), NFData a) => NFData (Vec n a) where
+instance (Arity n, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()
   {-# INLINE rnf #-}
 
 type instance Mutable (Vec n) = MVec n
 
-instance (Arity (Peano n)) => MVector (MVec n) a where
+instance (Arity n) => MVector (MVec n) a where
   new = do
     v <- newSmallArray (peanoToInt (proxy# @(Peano n))) uninitialised
     return $ MVec v
@@ -117,7 +117,7 @@ instance (Arity (Peano n)) => MVector (MVec n) a where
   unsafeWrite (MVec v) i x = writeSmallArray v i x
   {-# INLINE unsafeWrite #-}
 
-instance (Arity (Peano n)) => IVector (Vec n) a where
+instance (Arity n) => IVector (Vec n) a where
   unsafeFreeze (MVec v)   = do { a <- unsafeFreezeSmallArray v; return $! Vec  a }
   unsafeThaw   (Vec  v)   = do { a <- unsafeThawSmallArray   v; return $! MVec a }
   unsafeIndex  (Vec  v) i = indexSmallArray v i
@@ -130,47 +130,47 @@ instance (Arity (Peano n)) => IVector (Vec n) a where
 type instance Dim  (Vec  n) = Peano n
 type instance DimM (MVec n) = Peano n
 
-instance (Arity (Peano n)) => Vector (Vec n) a where
+instance (Arity n) => Vector (Vec n) a where
   construct  = constructVec
   inspect    = inspectVec
   basicIndex = index
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-instance (Arity (Peano n)) => VectorN Vec n a
+instance (Arity n) => VectorN Vec n a
 
-instance (Arity (Peano n), Eq a) => Eq (Vec n a) where
+instance (Arity n, Eq a) => Eq (Vec n a) where
   (==) = eq
   {-# INLINE (==) #-}
-instance (Arity (Peano n), Ord a) => Ord (Vec n a) where
+instance (Arity n, Ord a) => Ord (Vec n a) where
   compare = ord
   {-# INLINE compare #-}
 
-instance (Arity (Peano n), Monoid a) => Monoid (Vec n a) where
+instance (Arity n, Monoid a) => Monoid (Vec n a) where
   mempty  = replicate mempty
   mappend = (<>)
   {-# INLINE mempty  #-}
   {-# INLINE mappend #-}
 
-instance (Arity (Peano n), Semigroup a) => Semigroup (Vec n a) where
+instance (Arity n, Semigroup a) => Semigroup (Vec n a) where
   (<>) = zipWith (<>)
   {-# INLINE (<>) #-}
 
-instance Arity (Peano n) => Functor (Vec n) where
+instance Arity n => Functor (Vec n) where
   {-# INLINE fmap #-}
   fmap = map
 
-instance Arity (Peano n) => Applicative (Vec n) where
+instance Arity n => Applicative (Vec n) where
   pure  = replicate
   (<*>) = zipWith ($)
   {-# INLINE pure  #-}
   {-# INLINE (<*>) #-}
 
-instance Arity (Peano n) => F.Foldable (Vec n) where
+instance Arity n => F.Foldable (Vec n) where
   foldr = foldr
   {-# INLINE foldr #-}
 
-instance Arity (Peano n) => T.Traversable (Vec n) where
+instance Arity n => T.Traversable (Vec n) where
   sequenceA = sequenceA
   traverse  = traverse
   {-# INLINE sequenceA #-}

--- a/fixed-vector/Data/Vector/Fixed/Cont.hs
+++ b/fixed-vector/Data/Vector/Fixed/Cont.hs
@@ -28,7 +28,8 @@ module Data.Vector.Fixed.Cont (
     -- * N-ary functions
   , Fn
   , Fun(..)
-  , Arity(..)
+  , Arity
+  , ArityPeano(..)
   , apply
   , applyM
   , Index(..)
@@ -192,14 +193,14 @@ type family Fn (n :: PeanoNum) (a :: Type) (b :: Type) where
 newtype Fun n a b = Fun { unFun :: Fn n a b }
 
 
-instance Arity n => Functor (Fun n a) where
+instance ArityPeano n => Functor (Fun n a) where
   fmap f fun
      = accum (\(T_Flip g) a -> T_Flip (curryFirst g a))
              (\(T_Flip x)   -> f (unFun x))
              (T_Flip fun)
   {-# INLINE fmap #-}
 
-instance Arity n => Applicative (Fun n a) where
+instance ArityPeano n => Applicative (Fun n a) where
   pure x = accum (\Proxy _ -> Proxy)
                  (\Proxy   -> x)
                   Proxy
@@ -210,7 +211,7 @@ instance Arity n => Applicative (Fun n a) where
   {-# INLINE pure  #-}
   {-# INLINE (<*>) #-}
 
-instance Arity n => Monad (Fun n a) where
+instance ArityPeano n => Monad (Fun n a) where
   return  = pure
   f >>= g = shuffleFun g <*> f
   {-# INLINE return #-}
@@ -224,8 +225,10 @@ data T_ap a b c n = T_ap (Fn n a b) (Fn n a c)
 -- Generic operations of N-ary functions
 ----------------------------------------------------------------
 
+type Arity n = ArityPeano (Peano n)
+
 -- | Type class for handling /n/-ary functions.
-class Arity n where
+class ArityPeano n where
   -- | Left fold over /n/ elements exposed as n-ary function. These
   --   elements are supplied as arguments to the function.
   accum :: (forall k. t ('S k) -> a -> t k) -- ^ Fold function
@@ -267,7 +270,7 @@ newtype T_gunfold c r a n = T_gunfold (c (Fn n a r))
 
 
 -- | Apply all parameters to the function.
-apply :: Arity n
+apply :: ArityPeano n
       => (forall k. t ('S k) -> (a, t k)) -- ^ Get value to apply to function
       -> t n                              -- ^ Initial value
       -> ContVec n a                      -- ^ N-ary function
@@ -275,7 +278,7 @@ apply :: Arity n
 apply step z = fst (applyFun step z)
 
 -- | Apply all parameters to the function using applicative actions.
-applyM :: (Applicative f, Arity n)
+applyM :: (Applicative f, ArityPeano n)
        => (forall k. t ('S k) -> (f a, t k)) -- ^ Get value to apply to function
        -> t n                                -- ^ Initial value
        -> f (ContVec n a)
@@ -292,7 +295,7 @@ class Index (k :: PeanoNum) (n :: PeanoNum) where
 
 
 
-instance Arity 'Z where
+instance ArityPeano 'Z where
   accum      _ g t = Fun $ g t
   applyFun   _ t   = (ContVec unFun, t)
   applyFunM  _ t   = (pure (ContVec unFun), t)
@@ -306,7 +309,7 @@ instance Arity 'Z where
   {-# INLINE reverseF    #-}
   {-# INLINE gunfoldF    #-}
 
-instance Arity n => Arity ('S n) where
+instance ArityPeano n => ArityPeano ('S n) where
   accum     f g t = Fun $ \a -> unFun $ accum f g (f t a)
   applyFun  f t   = let (a,t') = f t
                         (v,tZ) = applyFun f t'
@@ -324,7 +327,7 @@ instance Arity n => Arity ('S n) where
   {-# INLINE reverseF    #-}
   {-# INLINE gunfoldF    #-}
 
-instance Arity n => Index 'Z ('S n) where
+instance ArityPeano n => Index 'Z ('S n) where
   getF  _       = uncurryFirst pure
   putF  _ a f   = Fun $ \_ -> unFun f a
   lensF _ f fun = Fun $ \a -> unFun $
@@ -375,7 +378,7 @@ uncurryFirst = coerce
 {-# INLINE uncurryFirst #-}
 
 -- | Curry last parameter of n-ary function
-curryLast :: Arity n => Fun ('S n) a b -> Fun n a (a -> b)
+curryLast :: ArityPeano n => Fun ('S n) a b -> Fun n a (a -> b)
 {-# INLINE curryLast #-}
 -- NOTE: This function is essentially rearrangement of newtypes. Since
 --       Fn is closed type family it couldn't be extended and it's
@@ -386,7 +389,7 @@ curryLast = unsafeCoerce
 
 
 -- | Curry /n/ first parameters of n-ary function
-curryMany :: forall n k a b. Arity n
+curryMany :: forall n k a b. ArityPeano n
           => Fun (Add n k) a b -> Fun n a (Fun k a b)
 {-# INLINE curryMany #-}
 -- NOTE: It's same as curryLast
@@ -395,7 +398,7 @@ curryMany = unsafeCoerce
 
 -- | Apply last parameter to function. Unlike 'apFun' we need to
 --   traverse all parameters but last hence 'Arity' constraint.
-apLast :: Arity n => Fun ('S n) a b -> a -> Fun n a b
+apLast :: ArityPeano n => Fun ('S n) a b -> a -> Fun n a b
 apLast f x = fmap ($ x) $ curryLast f
 {-# INLINE apLast #-}
 
@@ -405,7 +408,7 @@ withFun f fun = Fun $ \a -> unFun $ f $ curryFirst fun a
 {-# INLINE withFun #-}
 
 -- | Move function parameter to the result of N-ary function.
-shuffleFun :: Arity n
+shuffleFun :: ArityPeano n
            => (b -> Fun n a r) -> Fun n a (b -> r)
 {-# INLINE shuffleFun #-}
 shuffleFun f0
@@ -438,7 +441,7 @@ type family Dim (v :: Type -> Type) :: PeanoNum
 --   > instance Vector V2 a where
 --   >   construct                = Fun V2
 --   >   inspect (V2 a b) (Fun f) = f a b
-class Arity (Dim v) => Vector v a where
+class ArityPeano (Dim v) => Vector v a where
   -- | N-ary function for creation of vectors.
   construct :: Fun (Dim v) a (v a)
   -- | Deconstruction of vector.
@@ -451,13 +454,13 @@ class Arity (Dim v) => Vector v a where
 
 -- | Vector parametrized by length. In ideal world it should be:
 --
--- > forall n. (Arity n, Vector (v n) a, Dim (v n) ~ n) => VectorN v a
+-- > forall n. (ArityPeano n, Vector (v n) a, Dim (v n) ~ n) => VectorN v a
 --
 -- Alas polymorphic constraints aren't allowed in haskell.
 class (Vector (v n) a, Dim (v n) ~ Peano n) => VectorN v n a
 
 -- | Length of vector. Function doesn't evaluate its argument.
-length :: forall v a. Arity (Dim v) => v a -> Int
+length :: forall v a. ArityPeano (Dim v) => v a -> Int
 {-# INLINE length #-}
 length _ = peanoToInt (proxy# @(Dim v))
 
@@ -477,7 +480,7 @@ consPeano :: a -> ContVec n a -> ContVec ('S n) a
 consPeano a (ContVec cont) = ContVec $ \f -> cont $ curryFirst f a
 {-# INLINE consPeano #-}
 
-instance Arity n => Vector (ContVec n) a where
+instance ArityPeano n => Vector (ContVec n) a where
   construct = accum
     (\(T_mkN f) a -> T_mkN (f . consPeano a))
     (\(T_mkN f)   -> f (ContVec unFun))
@@ -490,42 +493,42 @@ newtype T_mkN n_tot a n = T_mkN (ContVec n a -> ContVec n_tot a)
 
 
 
-instance (Eq a, Arity n) => Eq (ContVec n a) where
+instance (Eq a, ArityPeano n) => Eq (ContVec n a) where
   a == b = and $ zipWith (==) a b
   {-# INLINE (==) #-}
 
-instance (Ord a, Arity n) => Ord (ContVec n a) where
+instance (Ord a, ArityPeano n) => Ord (ContVec n a) where
   compare a b = foldl mappend mempty $ zipWith compare a b
   {-# INLINE compare #-}
 
-instance (Arity n, Monoid a) => Monoid (ContVec n a) where
+instance (ArityPeano n, Monoid a) => Monoid (ContVec n a) where
   mempty = replicate mempty
   {-# INLINE mempty  #-}
 
-instance (Arity n, Semigroup a) => Semigroup (ContVec n a) where
+instance (ArityPeano n, Semigroup a) => Semigroup (ContVec n a) where
   (<>) = zipWith (<>)
   {-# INLINE (<>) #-}
 
 
-instance (Arity n) => Functor (ContVec n) where
+instance (ArityPeano n) => Functor (ContVec n) where
   fmap = map
   {-# INLINE fmap #-}
 
-instance (Arity n) => Applicative (ContVec n) where
+instance (ArityPeano n) => Applicative (ContVec n) where
   pure  = replicate
   (<*>) = zipWith ($)
   {-# INLINE pure  #-}
   {-# INLINE (<*>) #-}
 
-instance (Arity n) => F.Foldable (ContVec n) where
+instance (ArityPeano n) => F.Foldable (ContVec n) where
   foldr = foldr
   {-# INLINE foldr #-}
 
-instance (Arity n) => F.Traversable (ContVec n) where
+instance (ArityPeano n) => F.Traversable (ContVec n) where
   sequenceA v = inspect v $ sequenceAF construct
   {-# INLINE sequenceA #-}
 
-sequenceAF :: forall f n a b. (Applicative f, Arity n)
+sequenceAF :: forall f n a b. (Applicative f, ArityPeano n)
      => Fun n a b -> Fun n (f a) (f b)
 {-# INLINE sequenceAF #-}
 sequenceAF (Fun f0)
@@ -554,7 +557,7 @@ empty = ContVec (\(Fun r) -> r)
 
 -- | Convert list to continuation-based vector. Will throw error if
 --   list is shorter than resulting vector.
-fromList :: Arity n => [a] -> ContVec n a
+fromList :: ArityPeano n => [a] -> ContVec n a
 {-# INLINE fromList #-}
 fromList xs =
   apply step (Const xs)
@@ -564,7 +567,7 @@ fromList xs =
 
 -- | Same as 'fromList' bu throws error is list doesn't have same
 --   length as vector.
-fromList' :: forall n a. Arity n => [a] -> ContVec n a
+fromList' :: forall n a. ArityPeano n => [a] -> ContVec n a
 {-# INLINE fromList' #-}
 fromList' xs =
   let step (Const []    ) = error "Data.Vector.Fixed.Cont.fromList': too few elements"
@@ -576,7 +579,7 @@ fromList' xs =
 
 -- | Convert list to continuation-based vector. Will fail with
 --   'Nothing' if list doesn't have right length.
-fromListM :: forall n a. Arity n => [a] -> Maybe (ContVec n a)
+fromListM :: forall n a. ArityPeano n => [a] -> Maybe (ContVec n a)
 {-# INLINE fromListM #-}
 fromListM xs = case applyFunM step (Const xs :: Const [a] n) of
   (Just v, Const []) -> Just v
@@ -587,46 +590,46 @@ fromListM xs = case applyFunM step (Const xs :: Const [a] n) of
 
 
 -- | Convert vector to the list
-toList :: (Arity n) => ContVec n a -> [a]
+toList :: (ArityPeano n) => ContVec n a -> [a]
 toList = foldr (:) []
 {-# INLINE toList #-}
 
 
 -- | Execute monadic action for every element of vector. Synonym for 'pure'.
-replicate :: (Arity n) => a -> ContVec n a
+replicate :: (ArityPeano n) => a -> ContVec n a
 {-# INLINE replicate #-}
 replicate a = apply (\Proxy -> (a, Proxy)) Proxy
 
 -- | Execute monadic action for every element of vector.
-replicateM :: (Arity n, Applicative f) => f a -> f (ContVec n a)
+replicateM :: (ArityPeano n, Applicative f) => f a -> f (ContVec n a)
 {-# INLINE replicateM #-}
 replicateM act
   = applyM (\Proxy -> (act, Proxy)) Proxy
 
 
 -- | Generate vector from function which maps element's index to its value.
-generate :: (Arity n) => (Int -> a) -> ContVec n a
+generate :: (ArityPeano n) => (Int -> a) -> ContVec n a
 {-# INLINE generate #-}
 generate f =
   apply (\(Const n) -> (f n, Const (n + 1))) (Const 0)
 
 -- | Generate vector from monadic function which maps element's index
 --   to its value.
-generateM :: (Applicative f, Arity n) => (Int -> f a) -> f (ContVec n a)
+generateM :: (Applicative f, ArityPeano n) => (Int -> f a) -> f (ContVec n a)
 {-# INLINE generateM #-}
 generateM f =
   applyM (\(Const n) -> (f n, Const (n + 1))) (Const 0)
 
 
 -- | Unfold vector.
-unfoldr :: Arity n => (b -> (a,b)) -> b -> ContVec n a
+unfoldr :: ArityPeano n => (b -> (a,b)) -> b -> ContVec n a
 {-# INLINE unfoldr #-}
 unfoldr f b0 =
   apply (\(Const b) -> let (a,b') = f b in (a, Const b'))
         (Const b0)
 
 -- | Unit vector along Nth axis.
-basis :: (Num a, Arity n) => Int -> ContVec n a
+basis :: (Num a, ArityPeano n) => Int -> ContVec n a
 {-# INLINE basis #-}
 basis n0 =
   apply (\(Const n) -> (if n == 0 then 1 else 0, Const (n - 1)))
@@ -672,23 +675,23 @@ mk8 a1 a2 a3 a4 a5 a6 a7 a8 = ContVec $ \(Fun f) -> f a1 a2 a3 a4 a5 a6 a7 a8
 ----------------------------------------------------------------
 
 -- | Map over vector. Synonym for 'fmap'
-map :: (Arity n) => (a -> b) -> ContVec n a -> ContVec n b
+map :: (ArityPeano n) => (a -> b) -> ContVec n a -> ContVec n b
 {-# INLINE map #-}
 map = imap . const
 
 -- | Apply function to every element of the vector and its index.
-imap :: (Arity n) => (Int -> a -> b) -> ContVec n a -> ContVec n b
+imap :: (ArityPeano n) => (Int -> a -> b) -> ContVec n a -> ContVec n b
 {-# INLINE imap #-}
 imap f (ContVec contA) = ContVec $
   contA . imapF f
 
 -- | Effectful map over vector.
-mapM :: (Arity n, Applicative f) => (a -> f b) -> ContVec n a -> f (ContVec n b)
+mapM :: (ArityPeano n, Applicative f) => (a -> f b) -> ContVec n a -> f (ContVec n b)
 {-# INLINE mapM #-}
 mapM = imapM . const
 
 -- | Apply monadic function to every element of the vector and its index.
-imapM :: (Arity n, Applicative f)
+imapM :: (ArityPeano n, Applicative f)
       => (Int -> a -> f b) -> ContVec n a -> f (ContVec n b)
 {-# INLINE imapM #-}
 imapM f v
@@ -696,18 +699,18 @@ imapM f v
   $ imapMF f construct
 
 -- | Apply monadic action to each element of vector and ignore result.
-mapM_ :: (Arity n, Applicative f) => (a -> f b) -> ContVec n a -> f ()
+mapM_ :: (ArityPeano n, Applicative f) => (a -> f b) -> ContVec n a -> f ()
 {-# INLINE mapM_ #-}
 mapM_ f = foldl (\m a -> m *> f a *> pure ()) (pure ())
 
 -- | Apply monadic action to each element of vector and its index and
 --   ignore result.
-imapM_ :: (Arity n, Applicative f) => (Int -> a -> f b) -> ContVec n a -> f ()
+imapM_ :: (ArityPeano n, Applicative f) => (Int -> a -> f b) -> ContVec n a -> f ()
 {-# INLINE imapM_ #-}
 imapM_ f = ifoldl (\m i a -> m *> f i a *> pure ()) (pure ())
 
 
-imapMF :: (Arity n, Applicative f)
+imapMF :: (ArityPeano n, Applicative f)
        => (Int -> a -> f b) -> Fun n b r -> Fun n a (f r)
 {-# INLINE imapMF #-}
 imapMF f (Fun funB) =
@@ -717,7 +720,7 @@ imapMF f (Fun funB) =
 
 data T_mapM a m r n = T_mapM Int (m (Fn n a r))
 
-imapF :: Arity n
+imapF :: ArityPeano n
       => (Int -> a -> b) -> Fun n b r -> Fun n a r
 {-# INLINE imapF #-}
 imapF f (Fun funB) =
@@ -728,18 +731,18 @@ imapF f (Fun funB) =
 data T_map a r n = T_map Int (Fn n a r)
 
 -- | Left scan over vector
-scanl :: (Arity n) => (b -> a -> b) -> b -> ContVec n a -> ContVec ('S n) b
+scanl :: (ArityPeano n) => (b -> a -> b) -> b -> ContVec n a -> ContVec ('S n) b
 {-# INLINE scanl #-}
 scanl f b0 (ContVec cont) = ContVec $
   cont . scanlF f b0
 
 -- | Left scan over vector
-scanl1 :: (Arity n) => (a -> a -> a) -> ContVec n a -> ContVec n a
+scanl1 :: (ArityPeano n) => (a -> a -> a) -> ContVec n a -> ContVec n a
 {-# INLINE scanl1 #-}
 scanl1 f (ContVec cont) = ContVec $
   cont . scanl1F f
 
-scanlF :: forall n a b r. (Arity n) => (b -> a -> b) -> b -> Fun ('S n) b r -> Fun n a r
+scanlF :: forall n a b r. (ArityPeano n) => (b -> a -> b) -> b -> Fun ('S n) b r -> Fun n a r
 scanlF f b0 (Fun fun0)
   = accum step fini start
   where
@@ -748,7 +751,7 @@ scanlF f b0 (Fun fun0)
     fini (T_scanl _ r) = r
     start = T_scanl b0 (fun0 b0)  :: T_scanl r b n
 
-scanl1F :: forall n a r. (Arity n) => (a -> a -> a) -> Fun n a r -> Fun n a r
+scanl1F :: forall n a r. (ArityPeano n) => (a -> a -> a) -> Fun n a r -> Fun n a r
 scanl1F f (Fun fun0) = accum step fini start
   where
     step  :: forall k. T_scanl1 r a ('S k) -> a -> T_scanl1 r a k
@@ -762,17 +765,17 @@ data T_scanl1 r a n = T_scanl1 (Maybe a) (Fn n a r)
 
 
 -- | Evaluate every action in the vector from left to right.
-sequence :: (Arity n, Applicative f) => ContVec n (f a) -> f (ContVec n a)
+sequence :: (ArityPeano n, Applicative f) => ContVec n (f a) -> f (ContVec n a)
 sequence = mapM id
 {-# INLINE sequence #-}
 
 -- | Evaluate every action in the vector from left to right and ignore result.
-sequence_ :: (Arity n, Applicative f) => ContVec n (f a) -> f ()
+sequence_ :: (ArityPeano n, Applicative f) => ContVec n (f a) -> f ()
 sequence_ = mapM_ id
 {-# INLINE sequence_ #-}
 
 -- | The dual of sequenceA
-distribute :: (Functor f, Arity n) => f (ContVec n a) -> ContVec n (f a)
+distribute :: (Functor f, ArityPeano n) => f (ContVec n a) -> ContVec n (f a)
 {-# INLINE distribute #-}
 distribute f0
   = apply step start
@@ -783,7 +786,7 @@ distribute f0
                      , Const $ fmap (\(_:x) -> x) f)
     start = Const (fmap toList f0)
 
-collect :: (Functor f, Arity n) => (a -> ContVec n b) -> f a -> ContVec n (f b)
+collect :: (Functor f, ArityPeano n) => (a -> ContVec n b) -> f a -> ContVec n (f b)
 collect f = distribute . fmap f
 {-# INLINE collect #-}
 
@@ -798,21 +801,21 @@ cons a (ContVec cont) = ContVec $ \f -> cont $ curryFirst f a
 {-# INLINE cons #-}
 
 -- | Prepend single element vector to another vector.
-consV :: Arity n => ContVec N1 a -> ContVec n a -> ContVec ('S n) a
+consV :: ArityPeano n => ContVec N1 a -> ContVec n a -> ContVec ('S n) a
 {-# INLINE consV #-}
 consV (ContVec cont1) (ContVec cont)
   = ContVec $ \f -> cont $ curryFirst f $ cont1 $ Fun id
 
 -- | /O(1)/ Append element to vector
-snoc :: Arity n => a -> ContVec n a -> ContVec ('S n) a
+snoc :: ArityPeano n => a -> ContVec n a -> ContVec ('S n) a
 snoc a (ContVec cont) = ContVec $ \f -> cont $ apLast f a
 {-# INLINE snoc #-}
 
 
 -- | Concatenate vector
-concat :: ( Arity n
-          , Arity k
-          , Arity (n `Add` k)
+concat :: ( ArityPeano n
+          , ArityPeano k
+          , ArityPeano (n `Add` k)
           )
        => ContVec n a -> ContVec k a -> ContVec (Add n k) a
 {-# INLINE concat #-}
@@ -821,25 +824,25 @@ concat v u = inspect u
            $ curryMany construct
 
 -- | Reverse order of elements in the vector
-reverse :: Arity n => ContVec n a -> ContVec n a
+reverse :: ArityPeano n => ContVec n a -> ContVec n a
 reverse (ContVec cont) = ContVec $ cont . reverseF
 {-# INLINE reverse #-}
 
 -- | Zip two vector together using function.
-zipWith :: (Arity n) => (a -> b -> c)
+zipWith :: (ArityPeano n) => (a -> b -> c)
         -> ContVec n a -> ContVec n b -> ContVec n c
 {-# INLINE zipWith #-}
 zipWith = izipWith . const
 
 -- | Zip three vectors together
-zipWith3 :: (Arity n) => (a -> b -> c -> d)
+zipWith3 :: (ArityPeano n) => (a -> b -> c -> d)
          -> ContVec n a -> ContVec n b -> ContVec n c -> ContVec n d
 {-# INLINE zipWith3 #-}
 zipWith3 f v1 v2 v3 = zipWith (\a (b, c) -> f a b c) v1 (zipWith (,) v2 v3)
 
 -- | Zip two vector together using function which takes element index
 --   as well.
-izipWith :: (Arity n) => (Int -> a -> b -> c)
+izipWith :: (ArityPeano n) => (Int -> a -> b -> c)
          -> ContVec n a -> ContVec n b -> ContVec n c
 {-# INLINE izipWith #-}
 izipWith f vecA vecB = ContVec $ \funC ->
@@ -848,35 +851,35 @@ izipWith f vecA vecB = ContVec $ \funC ->
   $ izipWithF f funC
 
 -- | Zip three vectors together
-izipWith3 :: (Arity n) => (Int -> a -> b -> c -> d)
+izipWith3 :: (ArityPeano n) => (Int -> a -> b -> c -> d)
           -> ContVec n a -> ContVec n b -> ContVec n c -> ContVec n d
 {-# INLINE izipWith3 #-}
 izipWith3 f v1 v2 v3 = izipWith (\i a (b, c) -> f i a b c) v1 (zipWith (,) v2 v3)
 
 -- | Zip two vector together using monadic function.
-zipWithM :: (Arity n, Applicative f) => (a -> b -> f c)
+zipWithM :: (ArityPeano n, Applicative f) => (a -> b -> f c)
          -> ContVec n a -> ContVec n b -> f (ContVec n c)
 {-# INLINE zipWithM #-}
 zipWithM f v w = sequence $ zipWith f v w
 
-zipWithM_ :: (Arity n, Applicative f)
+zipWithM_ :: (ArityPeano n, Applicative f)
           => (a -> b -> f c) -> ContVec n a -> ContVec n b -> f ()
 {-# INLINE zipWithM_ #-}
 zipWithM_ f xs ys = sequence_ (zipWith f xs ys)
 
 -- | Zip two vector together using monadic function which takes element
 --   index as well..
-izipWithM :: (Arity n, Applicative f) => (Int -> a -> b -> f c)
+izipWithM :: (ArityPeano n, Applicative f) => (Int -> a -> b -> f c)
           -> ContVec n a -> ContVec n b -> f (ContVec n c)
 {-# INLINE izipWithM #-}
 izipWithM f v w = sequence $ izipWith f v w
 
-izipWithM_ :: (Arity n, Applicative f)
+izipWithM_ :: (ArityPeano n, Applicative f)
            => (Int -> a -> b -> f c) -> ContVec n a -> ContVec n b -> f ()
 {-# INLINE izipWithM_ #-}
 izipWithM_ f xs ys = sequence_ (izipWith f xs ys)
 
-izipWithF :: (Arity n)
+izipWithF :: (ArityPeano n)
           => (Int -> a -> b -> c) -> Fun n c r -> Fun n a (Fun n b r)
 {-# INLINE izipWithF #-}
 izipWithF f (Fun g0) =
@@ -887,7 +890,7 @@ izipWithF f (Fun g0) =
        ) makeList
 
 
-makeList :: Arity n => Fun n a [a]
+makeList :: ArityPeano n => Fun n a [a]
 {-# INLINE makeList #-}
 makeList = accum
     (\(Const xs) x -> Const (xs . (x:)))
@@ -916,7 +919,7 @@ vector = runContVec construct
 {-# INLINE[1] vector #-}
 
 -- | Finalizer function for getting head of the vector.
-head :: (Arity n, n ~ 'S k) => ContVec n a -> a
+head :: (ArityPeano n, n ~ 'S k) => ContVec n a -> a
 {-# INLINE head #-}
 head
   = runContVec
@@ -926,7 +929,7 @@ head
 
 
 -- | /O(n)/ Get value at specified index.
-index :: Arity n => Int -> ContVec n a -> a
+index :: ArityPeano n => Int -> ContVec n a -> a
 {-# INLINE index #-}
 index n
   | n < 0     = error "Data.Vector.Fixed.Cont.index: index out of range"
@@ -944,14 +947,14 @@ index n
 
 
 -- | Twan van Laarhoven lens for continuation based vector
-element :: (Arity n, Functor f)
+element :: (ArityPeano n, Functor f)
         => Int -> (a -> f a) -> ContVec n a -> f (ContVec n a)
 {-# INLINE element #-}
 element i f v = inspect v
               $ elementF i f construct
 
 -- | Helper for implementation of Twan van Laarhoven lens.
-elementF :: forall a n f r. (Arity n, Functor f)
+elementF :: forall a n f r. (ArityPeano n, Functor f)
          => Int -> (a -> f a) -> Fun n a r -> Fun n a (f r)
 {-# INLINE elementF #-}
 elementF n f (Fun fun0) = accum step fini start
@@ -973,12 +976,12 @@ data T_lens f a r n = T_lens (Either (Int,(Fn n a r)) (f (Fn n a r)))
 
 
 -- | Left fold over continuation vector.
-foldl :: Arity n => (b -> a -> b) -> b -> ContVec n a -> b
+foldl :: ArityPeano n => (b -> a -> b) -> b -> ContVec n a -> b
 {-# INLINE foldl #-}
 foldl f = ifoldl (\b _ a -> f b a)
 
 -- | Left fold over continuation vector.
-ifoldl :: Arity n => (b -> Int -> a -> b) -> b -> ContVec n a -> b
+ifoldl :: ArityPeano n => (b -> Int -> a -> b) -> b -> ContVec n a -> b
 {-# INLINE ifoldl #-}
 ifoldl f b v
   = inspect v
@@ -987,14 +990,14 @@ ifoldl f b v
           (T_ifoldl 0 b)
 
 -- | Monadic left fold over continuation vector.
-foldM :: (Arity n, Monad m)
+foldM :: (ArityPeano n, Monad m)
       => (b -> a -> m b) -> b -> ContVec n a -> m b
 {-# INLINE foldM #-}
 foldM f x
   = foldl (\m a -> do{ b <- m; f b a}) (return x)
 
 -- | Monadic left fold over continuation vector.
-ifoldM :: (Arity n, Monad m)
+ifoldM :: (ArityPeano n, Monad m)
        => (b -> Int -> a -> m b) -> b -> ContVec n a -> m b
 {-# INLINE ifoldM #-}
 ifoldM f x
@@ -1007,11 +1010,11 @@ data T_ifoldl b n = T_ifoldl !Int b
 --
 -- > foldl1F f = Fun $ \a -> case foldlF f a :: Fun n a a of Fun g -> g
 --
--- But it require constraint `Arity n` whereas `Vector v a` gives
+-- But it require constraint `ArityPeano n` whereas `Vector v a` gives
 -- `Arity (S n)`.  Latter imply former but GHC cannot infer it.
 
 -- | Left fold.
-foldl1 :: (Arity n, n ~ 'S k) => (a -> a -> a) -> ContVec n a -> a
+foldl1 :: (ArityPeano n, n ~ 'S k) => (a -> a -> a) -> ContVec n a -> a
 {-# INLINE foldl1 #-}
 foldl1 f
   = runContVec
@@ -1020,12 +1023,12 @@ foldl1 f
           (Const Nothing)
 
 -- | Right fold over continuation vector
-foldr :: Arity n => (a -> b -> b) -> b -> ContVec n a -> b
+foldr :: ArityPeano n => (a -> b -> b) -> b -> ContVec n a -> b
 {-# INLINE foldr #-}
 foldr = ifoldr . const
 
 -- | Right fold over continuation vector
-ifoldr :: Arity n => (Int -> a -> b -> b) -> b -> ContVec n a -> b
+ifoldr :: ArityPeano n => (Int -> a -> b -> b) -> b -> ContVec n a -> b
 {-# INLINE ifoldr #-}
 ifoldr f z
   = runContVec
@@ -1036,44 +1039,44 @@ ifoldr f z
 data T_ifoldr b n = T_ifoldr Int (b -> b)
 
 -- | Sum all elements in the vector.
-sum :: (Num a, Arity n) => ContVec n a -> a
+sum :: (Num a, ArityPeano n) => ContVec n a -> a
 sum = foldl (+) 0
 {-# INLINE sum #-}
 
 -- | Minimal element of vector.
-minimum :: (Ord a, Arity n, n ~ 'S k) => ContVec n a -> a
+minimum :: (Ord a, ArityPeano n, n ~ 'S k) => ContVec n a -> a
 minimum = foldl1 min
 {-# INLINE minimum #-}
 
 -- | Maximal element of vector.
-maximum :: (Ord a, Arity n, n ~ 'S k) => ContVec n a -> a
+maximum :: (Ord a, ArityPeano n, n ~ 'S k) => ContVec n a -> a
 maximum = foldl1 max
 {-# INLINE maximum #-}
 
 -- | Conjunction of elements of a vector.
-and :: Arity n => ContVec n Bool -> Bool
+and :: ArityPeano n => ContVec n Bool -> Bool
 and = foldr (&&) True
 {-# INLINE and #-}
 
 -- | Disjunction of all elements of a vector.
-or :: Arity n => ContVec n Bool -> Bool
+or :: ArityPeano n => ContVec n Bool -> Bool
 or = foldr (||) False
 {-# INLINE or #-}
 
 -- | Determines whether all elements of vector satisfy predicate.
-all :: Arity n => (a -> Bool) -> ContVec n a -> Bool
+all :: ArityPeano n => (a -> Bool) -> ContVec n a -> Bool
 all f = foldr (\x b -> f x && b) True
 {-# INLINE all #-}
 
 -- | Determines whether any of element of vector satisfy predicate.
-any :: Arity n => (a -> Bool) -> ContVec n a -> Bool
+any :: ArityPeano n => (a -> Bool) -> ContVec n a -> Bool
 any f = foldr (\x b -> f x || b) False
 {-# INLINE any #-}
 
 -- | The 'find' function takes a predicate and a vector and returns
 --   the leftmost element of the vector matching the predicate,
 --   or 'Nothing' if there is no such element.
-find :: Arity n => (a -> Bool) -> ContVec n a -> Maybe a
+find :: ArityPeano n => (a -> Bool) -> ContVec n a -> Maybe a
 find f = foldl (\r x -> r <|> if f x then Just x else Nothing) Nothing
 {-# INLINE find #-}
 
@@ -1100,7 +1103,7 @@ gunfold f inj _
     gun = T_gunfold (inj $ unFun con) :: T_gunfold c (v a) a (Dim v)
 
 
-gfoldlF :: (Arity n, Data a)
+gfoldlF :: (ArityPeano n, Data a)
         => (forall x y. Data x => c (x -> y) -> x -> c y)
         -> c (Fn n a r) -> Fun n a (c r)
 gfoldlF f c0 = accum

--- a/fixed-vector/Data/Vector/Fixed/Cont.hs
+++ b/fixed-vector/Data/Vector/Fixed/Cont.hs
@@ -29,7 +29,6 @@ module Data.Vector.Fixed.Cont (
   , Fn
   , Fun(..)
   , Arity(..)
-  , arity
   , apply
   , applyM
   , Index(..)
@@ -282,11 +281,6 @@ applyM :: (Applicative f, Arity n)
        -> f (ContVec n a)
 {-# INLINE applyM #-}
 applyM f t = fst $ applyFunM f t
-
--- | Arity of function.
-arity :: KnownNat n => proxy n -> Int
-{-# INLINE arity #-}
-arity = fromIntegral . natVal
 
 
 -- | Type class for indexing of vector of length @n@ with statically

--- a/fixed-vector/Data/Vector/Fixed/Cont.hs
+++ b/fixed-vector/Data/Vector/Fixed/Cont.hs
@@ -757,17 +757,17 @@ collect f = distribute . fmap f
 {-# INLINE collect #-}
 
 -- | /O(1)/ Tail of vector.
-tail :: {-FIXME-} Arity n => ContVec (S n) a -> ContVec n a
+tail :: ContVec (S n) a -> ContVec n a
 tail (ContVec cont) = ContVec $ \f -> cont $ constFun f
 {-# INLINE tail #-}
 
 -- | /O(1)/ Prepend element to vector
-cons :: {-FIXME-} Arity n => a -> ContVec n a -> ContVec ('S n) a
+cons :: a -> ContVec n a -> ContVec ('S n) a
 cons a (ContVec cont) = ContVec $ \f -> cont $ curryFirst f a
 {-# INLINE cons #-}
 
 -- | Prepend single element vector to another vector.
-consV :: {-FIXME-} Arity n => ContVec N1 a -> ContVec n a -> ContVec ('S n) a
+consV :: Arity n => ContVec N1 a -> ContVec n a -> ContVec ('S n) a
 {-# INLINE consV #-}
 consV (ContVec cont1) (ContVec cont)
   = ContVec $ \f -> cont $ curryFirst f $ cont1 $ Fun id

--- a/fixed-vector/Data/Vector/Fixed/Cont.hs
+++ b/fixed-vector/Data/Vector/Fixed/Cont.hs
@@ -45,7 +45,6 @@ module Data.Vector.Fixed.Cont (
     -- * Vector type class
   , Dim
   , Vector(..)
-  , VectorN
   , length
     -- * Vector as continuation
   , ContVec(..)
@@ -451,13 +450,6 @@ class ArityPeano (Dim v) => Vector v a where
   basicIndex :: v a -> Int -> a
   basicIndex v i = index i (cvec v)
   {-# INLINE basicIndex #-}
-
--- | Vector parametrized by length. In ideal world it should be:
---
--- > forall n. (ArityPeano n, Vector (v n) a, Dim (v n) ~ n) => VectorN v a
---
--- Alas polymorphic constraints aren't allowed in haskell.
-class (Vector (v n) a, Dim (v n) ~ Peano n) => VectorN v n a
 
 -- | Length of vector. Function doesn't evaluate its argument.
 length :: forall v a. ArityPeano (Dim v) => v a -> Int

--- a/fixed-vector/Data/Vector/Fixed/Internal.hs
+++ b/fixed-vector/Data/Vector/Fixed/Internal.hs
@@ -21,7 +21,7 @@ import Foreign.Ptr      (Ptr,castPtr)
 import GHC.Exts         (proxy#)
 
 import           Data.Vector.Fixed.Cont (Vector(..),Dim,Arity,vector,Add,PeanoNum(..),
-                                         Peano,Index)
+                                         Peano,Index,ArityPeano)
 import qualified Data.Vector.Fixed.Cont as C
 
 import Prelude hiding ( replicate,map,zipWith,maximum,minimum,and,or,all,any
@@ -230,7 +230,7 @@ reverse = vector . C.reverse . C.cvec
 v ! n = runIndex n (C.cvec v)
 
 -- Used in rewriting of index function.
-runIndex :: Arity n => Int -> C.ContVec n r -> r
+runIndex :: ArityPeano n => Int -> C.ContVec n r -> r
 runIndex = C.index
 {-# INLINE[0] runIndex #-}
 

--- a/fixed-vector/Data/Vector/Fixed/Internal.hs
+++ b/fixed-vector/Data/Vector/Fixed/Internal.hs
@@ -20,7 +20,7 @@ import Foreign.Storable (Storable(..))
 import Foreign.Ptr      (Ptr,castPtr)
 import GHC.Exts         (proxy#)
 
-import           Data.Vector.Fixed.Cont (Vector(..),Dim,Arity,vector,Add,PeanoNum(..),
+import           Data.Vector.Fixed.Cont (Vector(..),Dim,vector,Add,PeanoNum(..),
                                          Peano,Index,ArityPeano)
 import qualified Data.Vector.Fixed.Cont as C
 

--- a/fixed-vector/Data/Vector/Fixed/Mutable.hs
+++ b/fixed-vector/Data/Vector/Fixed/Mutable.hs
@@ -13,7 +13,6 @@
 module Data.Vector.Fixed.Mutable (
     -- * Mutable vectors
     Arity
-  , arity
   , Mutable
   , DimM
   , MVector(..)
@@ -41,10 +40,8 @@ module Data.Vector.Fixed.Mutable (
 import Control.Applicative  (Const(..))
 import Control.Monad.ST
 import Control.Monad.Primitive
-import Data.Typeable  (Proxy(..))
 import Data.Kind      (Type)
-import GHC.TypeLits
-import Data.Vector.Fixed.Cont (Dim,PeanoNum(..),Peano,Arity,Fun(..),Vector(..),ContVec,arity,apply,accum,length)
+import Data.Vector.Fixed.Cont (Dim,PeanoNum(..),Arity,Fun(..),Vector(..),ContVec,apply,accum,length)
 import Prelude hiding (read,length,replicate)
 
 

--- a/fixed-vector/Data/Vector/Fixed/Primitive.hs
+++ b/fixed-vector/Data/Vector/Fixed/Primitive.hs
@@ -44,7 +44,7 @@ import Prelude (($),($!),undefined,seq)
 import Data.Vector.Fixed hiding (index)
 import Data.Vector.Fixed.Mutable (Mutable, MVector(..), IVector(..), DimM, constructVec, inspectVec, index)
 import qualified Data.Vector.Fixed.Cont     as C
-import           Data.Vector.Fixed.Cont     (Peano,Arity(..))
+import           Data.Vector.Fixed.Cont     (Peano,ArityPeano(..))
 import qualified Data.Vector.Fixed.Internal as I
 
 
@@ -74,16 +74,16 @@ type Vec5 = Vec 5
 -- Instances
 ----------------------------------------------------------------
 
-instance (Arity (Peano n), Prim a, Show a) => Show (Vec n a) where
+instance (Arity n, Prim a, Show a) => Show (Vec n a) where
   showsPrec = I.showsPrec
 
-instance (Arity (Peano n), Prim a, NFData a) => NFData (Vec n a) where
+instance (Arity n, Prim a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()
   {-# INLINE rnf #-}
 
 type instance Mutable (Vec n) = MVec n
 
-instance (Arity (Peano n), Prim a) => MVector (MVec n) a where
+instance (Arity n, Prim a) => MVector (MVec n) a where
   new = do
     v <- newByteArray $! peanoToInt (proxy# @(Peano n))
                        * sizeOf (undefined :: a)
@@ -98,7 +98,7 @@ instance (Arity (Peano n), Prim a) => MVector (MVec n) a where
   unsafeWrite (MVec v) i x = writeByteArray v i x
   {-# INLINE unsafeWrite #-}
 
-instance (Arity (Peano n), Prim a) => IVector (Vec n) a where
+instance (Arity n, Prim a) => IVector (Vec n) a where
   unsafeFreeze (MVec v)   = do { a <- unsafeFreezeByteArray v; return $! Vec  a }
   unsafeThaw   (Vec  v)   = do { a <- unsafeThawByteArray   v; return $! MVec a }
   unsafeIndex  (Vec  v) i = indexByteArray v i
@@ -111,34 +111,34 @@ instance (Arity (Peano n), Prim a) => IVector (Vec n) a where
 type instance Dim  (Vec  n) = Peano n
 type instance DimM (MVec n) = Peano n
 
-instance (Arity (Peano n), Prim a) => Vector (Vec n) a where
+instance (Arity n, Prim a) => Vector (Vec n) a where
   construct  = constructVec
   inspect    = inspectVec
   basicIndex = index
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-instance (Arity (Peano n), Prim a) => VectorN Vec n a
+instance (Arity n, Prim a) => VectorN Vec n a
 
-instance (Arity (Peano n), Prim a, Eq a) => Eq (Vec n a) where
+instance (Arity n, Prim a, Eq a) => Eq (Vec n a) where
   (==) = eq
   {-# INLINE (==) #-}
-instance (Arity (Peano n), Prim a, Ord a) => Ord (Vec n a) where
+instance (Arity n, Prim a, Ord a) => Ord (Vec n a) where
   compare = ord
   {-# INLINE compare #-}
 
-instance (Arity (Peano n), Prim a, Monoid a) => Monoid (Vec n a) where
+instance (Arity n, Prim a, Monoid a) => Monoid (Vec n a) where
   mempty  = replicate mempty
   mappend = (<>)
   {-# INLINE mempty  #-}
   {-# INLINE mappend #-}
 
-instance (Arity (Peano n), Prim a, Semigroup a) => Semigroup (Vec n a) where
+instance (Arity n, Prim a, Semigroup a) => Semigroup (Vec n a) where
   (<>) = zipWith (<>)
   {-# INLINE (<>) #-}
 
 
-instance (Typeable n, Arity (Peano n), Prim a, Data a) => Data (Vec n a) where
+instance (Typeable n, Arity n, Prim a, Data a) => Data (Vec n a) where
   gfoldl       = C.gfoldl
   gunfold      = C.gunfold
   toConstr   _ = con_Vec
@@ -150,7 +150,7 @@ ty_Vec  = mkDataType "Data.Vector.Fixed.Primitive.Vec" [con_Vec]
 con_Vec :: Constr
 con_Vec = mkConstr ty_Vec "Vec" [] Prefix
 
-instance (Foreign.Storable a, Prim a, Arity (Peano n)) => Foreign.Storable (Vec n a) where
+instance (Foreign.Storable a, Prim a, Arity n) => Foreign.Storable (Vec n a) where
   alignment = defaultAlignemnt
   sizeOf    = defaultSizeOf
   peek      = defaultPeek

--- a/fixed-vector/Data/Vector/Fixed/Primitive.hs
+++ b/fixed-vector/Data/Vector/Fixed/Primitive.hs
@@ -118,7 +118,6 @@ instance (Arity n, Prim a) => Vector (Vec n) a where
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-instance (Arity n, Prim a) => VectorN Vec n a
 
 instance (Arity n, Prim a, Eq a) => Eq (Vec n a) where
   (==) = eq

--- a/fixed-vector/Data/Vector/Fixed/Primitive.hs
+++ b/fixed-vector/Data/Vector/Fixed/Primitive.hs
@@ -2,9 +2,11 @@
 {-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MagicHash             #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 -- |
@@ -34,13 +36,15 @@ import Data.Primitive.ByteArray
 import Data.Primitive
 import qualified Foreign.Storable as Foreign (Storable(..))
 import GHC.TypeLits
+import GHC.Exts (proxy#)
 import Prelude (Show(..),Eq(..),Ord(..),Num(..))
 import Prelude (($),($!),undefined,seq)
 
 
 import Data.Vector.Fixed hiding (index)
-import Data.Vector.Fixed.Mutable (Mutable, MVector(..), IVector(..), DimM, constructVec, inspectVec, arity, index)
+import Data.Vector.Fixed.Mutable (Mutable, MVector(..), IVector(..), DimM, constructVec, inspectVec, index)
 import qualified Data.Vector.Fixed.Cont     as C
+import           Data.Vector.Fixed.Cont     (Peano,Arity(..))
 import qualified Data.Vector.Fixed.Internal as I
 
 
@@ -70,31 +74,31 @@ type Vec5 = Vec 5
 -- Instances
 ----------------------------------------------------------------
 
-instance (Arity n, Prim a, Show a) => Show (Vec n a) where
+instance (Arity (Peano n), Prim a, Show a) => Show (Vec n a) where
   showsPrec = I.showsPrec
 
-instance (Arity n, Prim a, NFData a) => NFData (Vec n a) where
+instance (Arity (Peano n), Prim a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()
   {-# INLINE rnf #-}
 
 type instance Mutable (Vec n) = MVec n
 
-instance (Arity n, Prim a) => MVector (MVec n) a where
+instance (Arity (Peano n), Prim a) => MVector (MVec n) a where
   new = do
-    v <- newByteArray $! arity (Proxy :: Proxy n)
+    v <- newByteArray $! peanoToInt (proxy# @(Peano n))
                        * sizeOf (undefined :: a)
     return $ MVec v
   {-# INLINE new         #-}
   copy                       = move
   {-# INLINE copy        #-}
-  move (MVec dst) (MVec src) = copyMutableByteArray dst 0 src 0 (arity (Proxy :: Proxy n))
+  move (MVec dst) (MVec src) = copyMutableByteArray dst 0 src 0 (peanoToInt (proxy# @(Peano n)))
   {-# INLINE move        #-}
   unsafeRead  (MVec v) i   = readByteArray  v i
   {-# INLINE unsafeRead  #-}
   unsafeWrite (MVec v) i x = writeByteArray v i x
   {-# INLINE unsafeWrite #-}
 
-instance (Arity n, Prim a) => IVector (Vec n) a where
+instance (Arity (Peano n), Prim a) => IVector (Vec n) a where
   unsafeFreeze (MVec v)   = do { a <- unsafeFreezeByteArray v; return $! Vec  a }
   unsafeThaw   (Vec  v)   = do { a <- unsafeThawByteArray   v; return $! MVec a }
   unsafeIndex  (Vec  v) i = indexByteArray v i
@@ -104,37 +108,37 @@ instance (Arity n, Prim a) => IVector (Vec n) a where
 
 
 
-type instance Dim  (Vec  n) = n
-type instance DimM (MVec n) = n
+type instance Dim  (Vec  n) = Peano n
+type instance DimM (MVec n) = Peano n
 
-instance (Arity n, Prim a) => Vector (Vec n) a where
+instance (Arity (Peano n), Prim a) => Vector (Vec n) a where
   construct  = constructVec
   inspect    = inspectVec
   basicIndex = index
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-instance (Arity n, Prim a) => VectorN Vec n a
+instance (Arity (Peano n), Prim a) => VectorN Vec n a
 
-instance (Arity n, Prim a, Eq a) => Eq (Vec n a) where
+instance (Arity (Peano n), Prim a, Eq a) => Eq (Vec n a) where
   (==) = eq
   {-# INLINE (==) #-}
-instance (Arity n, Prim a, Ord a) => Ord (Vec n a) where
+instance (Arity (Peano n), Prim a, Ord a) => Ord (Vec n a) where
   compare = ord
   {-# INLINE compare #-}
 
-instance (Arity n, Prim a, Monoid a) => Monoid (Vec n a) where
+instance (Arity (Peano n), Prim a, Monoid a) => Monoid (Vec n a) where
   mempty  = replicate mempty
   mappend = (<>)
   {-# INLINE mempty  #-}
   {-# INLINE mappend #-}
 
-instance (Arity n, Prim a, Semigroup a) => Semigroup (Vec n a) where
+instance (Arity (Peano n), Prim a, Semigroup a) => Semigroup (Vec n a) where
   (<>) = zipWith (<>)
   {-# INLINE (<>) #-}
 
 
-instance (Typeable n, Arity n, Prim a, Data a) => Data (Vec n a) where
+instance (Typeable n, Arity (Peano n), Prim a, Data a) => Data (Vec n a) where
   gfoldl       = C.gfoldl
   gunfold      = C.gunfold
   toConstr   _ = con_Vec
@@ -146,7 +150,7 @@ ty_Vec  = mkDataType "Data.Vector.Fixed.Primitive.Vec" [con_Vec]
 con_Vec :: Constr
 con_Vec = mkConstr ty_Vec "Vec" [] Prefix
 
-instance (Foreign.Storable a, Prim a, Arity n) => Foreign.Storable (Vec n a) where
+instance (Foreign.Storable a, Prim a, Arity (Peano n)) => Foreign.Storable (Vec n a) where
   alignment = defaultAlignemnt
   sizeOf    = defaultSizeOf
   peek      = defaultPeek

--- a/fixed-vector/Data/Vector/Fixed/Storable.hs
+++ b/fixed-vector/Data/Vector/Fixed/Storable.hs
@@ -45,6 +45,7 @@ import Prelude ( Show(..),Eq(..),Ord(..),Num(..),Monad(..),IO,Int
 import Data.Vector.Fixed hiding (index)
 import Data.Vector.Fixed.Mutable (Mutable, MVector(..), IVector(..), DimM, constructVec, inspectVec, arity, index)
 import qualified Data.Vector.Fixed.Cont     as C
+import           Data.Vector.Fixed.Cont     (Peano)
 import qualified Data.Vector.Fixed.Internal as I
 
 
@@ -94,16 +95,16 @@ unsafeWith f (Vec fp) = f (getPtr fp)
 -- Instances
 ----------------------------------------------------------------
 
-instance (Arity n, Storable a, Show a) => Show (Vec n a) where
+instance (Arity (Peano n), Storable a, Show a) => Show (Vec n a) where
   showsPrec = I.showsPrec
 
-instance (Arity n, Storable a, NFData a) => NFData (Vec n a) where
+instance (Arity (Peano n), Storable a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()
   {-# INLINE rnf #-}
 
 type instance Mutable (Vec n) = MVec n
 
-instance (Arity n, Storable a) => MVector (MVec n) a where
+instance (Arity (Peano n), Storable a) => MVector (MVec n) a where
   new = unsafePrimToPrim $ do
     fp <- mallocVector $ arity (Proxy :: Proxy n)
     return $ MVec fp
@@ -130,7 +131,7 @@ instance (Arity n, Storable a) => MVector (MVec n) a where
   {-# INLINE unsafeWrite #-}
 
 
-instance (Arity n, Storable a) => IVector (Vec n) a where
+instance (Arity (Peano n), Storable a) => IVector (Vec n) a where
   unsafeFreeze (MVec fp)   = return $ Vec  fp
   unsafeThaw   (Vec  fp)   = return $ MVec fp
   unsafeIndex  (Vec  fp) i
@@ -141,36 +142,36 @@ instance (Arity n, Storable a) => IVector (Vec n) a where
   {-# INLINE unsafeIndex  #-}
 
 
-type instance Dim  (Vec  n) = n
-type instance DimM (MVec n) = n
+type instance Dim  (Vec  n) = Peano n
+type instance DimM (MVec n) = Peano n
 
-instance (Arity n, Storable a) => Vector (Vec n) a where
+instance (Arity (Peano n), Storable a) => Vector (Vec n) a where
   construct  = constructVec
   inspect    = inspectVec
   basicIndex = index
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-instance (Arity n, Storable a) => VectorN Vec n a
+instance (Arity (Peano n), Storable a) => VectorN Vec n a
 
-instance (Arity n, Storable a, Eq a) => Eq (Vec n a) where
+instance (Arity (Peano n), Storable a, Eq a) => Eq (Vec n a) where
   (==) = eq
   {-# INLINE (==) #-}
-instance (Arity n, Storable a, Ord a) => Ord (Vec n a) where
+instance (Arity (Peano n), Storable a, Ord a) => Ord (Vec n a) where
   compare = ord
   {-# INLINE compare #-}
 
-instance (Arity n, Storable a, Monoid a) => Monoid (Vec n a) where
+instance (Arity (Peano n), Storable a, Monoid a) => Monoid (Vec n a) where
   mempty  = replicate mempty
   mappend = (<>)
   {-# INLINE mempty  #-}
   {-# INLINE mappend #-}
 
-instance (Arity n, Storable a, Semigroup a) => Semigroup (Vec n a) where
+instance (Arity (Peano n), Storable a, Semigroup a) => Semigroup (Vec n a) where
   (<>) = zipWith (<>)
   {-# INLINE (<>) #-}
 
-instance (Arity n, Storable a) => Storable (Vec n a) where
+instance (Arity (Peano n), Storable a) => Storable (Vec n a) where
   sizeOf    _ = arity  (Proxy :: Proxy n)
               * sizeOf (undefined :: a)
   alignment _ = alignment (undefined :: a)
@@ -183,7 +184,7 @@ instance (Arity n, Storable a) => Storable (Vec n a) where
     = withForeignPtr fp $ \p ->
       moveArray (castPtr ptr) p (arity (Proxy :: Proxy n))
 
-instance (Typeable n, Arity n, Storable a, Data a) => Data (Vec n a) where
+instance (Typeable n, Arity (Peano n), Storable a, Data a) => Data (Vec n a) where
   gfoldl       = C.gfoldl
   gunfold      = C.gunfold
   toConstr   _ = con_Vec

--- a/fixed-vector/Data/Vector/Fixed/Storable.hs
+++ b/fixed-vector/Data/Vector/Fixed/Storable.hs
@@ -155,7 +155,6 @@ instance (Arity n, Storable a) => Vector (Vec n) a where
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-instance (Arity n, Storable a) => VectorN Vec n a
 
 instance (Arity n, Storable a, Eq a) => Eq (Vec n a) where
   (==) = eq

--- a/fixed-vector/Data/Vector/Fixed/Storable.hs
+++ b/fixed-vector/Data/Vector/Fixed/Storable.hs
@@ -48,7 +48,7 @@ import Prelude ( Show(..),Eq(..),Ord(..),Num(..),Monad(..),IO,Int
 import Data.Vector.Fixed hiding (index)
 import Data.Vector.Fixed.Mutable (Mutable, MVector(..), IVector(..), DimM, constructVec, inspectVec, index)
 import qualified Data.Vector.Fixed.Cont     as C
-import           Data.Vector.Fixed.Cont     (Peano,Arity(..))
+import           Data.Vector.Fixed.Cont     (Peano,ArityPeano(..))
 import qualified Data.Vector.Fixed.Internal as I
 
 
@@ -98,16 +98,16 @@ unsafeWith f (Vec fp) = f (getPtr fp)
 -- Instances
 ----------------------------------------------------------------
 
-instance (Arity (Peano n), Storable a, Show a) => Show (Vec n a) where
+instance (Arity n, Storable a, Show a) => Show (Vec n a) where
   showsPrec = I.showsPrec
 
-instance (Arity (Peano n), Storable a, NFData a) => NFData (Vec n a) where
+instance (Arity n, Storable a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()
   {-# INLINE rnf #-}
 
 type instance Mutable (Vec n) = MVec n
 
-instance (Arity (Peano n), Storable a) => MVector (MVec n) a where
+instance (Arity n, Storable a) => MVector (MVec n) a where
   new = unsafePrimToPrim $ do
     fp <- mallocVector (peanoToInt (proxy# @(Peano n)))
     return $ MVec fp
@@ -134,7 +134,7 @@ instance (Arity (Peano n), Storable a) => MVector (MVec n) a where
   {-# INLINE unsafeWrite #-}
 
 
-instance (Arity (Peano n), Storable a) => IVector (Vec n) a where
+instance (Arity n, Storable a) => IVector (Vec n) a where
   unsafeFreeze (MVec fp)   = return $ Vec  fp
   unsafeThaw   (Vec  fp)   = return $ MVec fp
   unsafeIndex  (Vec  fp) i
@@ -148,33 +148,33 @@ instance (Arity (Peano n), Storable a) => IVector (Vec n) a where
 type instance Dim  (Vec  n) = Peano n
 type instance DimM (MVec n) = Peano n
 
-instance (Arity (Peano n), Storable a) => Vector (Vec n) a where
+instance (Arity n, Storable a) => Vector (Vec n) a where
   construct  = constructVec
   inspect    = inspectVec
   basicIndex = index
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-instance (Arity (Peano n), Storable a) => VectorN Vec n a
+instance (Arity n, Storable a) => VectorN Vec n a
 
-instance (Arity (Peano n), Storable a, Eq a) => Eq (Vec n a) where
+instance (Arity n, Storable a, Eq a) => Eq (Vec n a) where
   (==) = eq
   {-# INLINE (==) #-}
-instance (Arity (Peano n), Storable a, Ord a) => Ord (Vec n a) where
+instance (Arity n, Storable a, Ord a) => Ord (Vec n a) where
   compare = ord
   {-# INLINE compare #-}
 
-instance (Arity (Peano n), Storable a, Monoid a) => Monoid (Vec n a) where
+instance (Arity n, Storable a, Monoid a) => Monoid (Vec n a) where
   mempty  = replicate mempty
   mappend = (<>)
   {-# INLINE mempty  #-}
   {-# INLINE mappend #-}
 
-instance (Arity (Peano n), Storable a, Semigroup a) => Semigroup (Vec n a) where
+instance (Arity n, Storable a, Semigroup a) => Semigroup (Vec n a) where
   (<>) = zipWith (<>)
   {-# INLINE (<>) #-}
 
-instance (Arity (Peano n), Storable a) => Storable (Vec n a) where
+instance (Arity n, Storable a) => Storable (Vec n a) where
   sizeOf    = defaultSizeOf
   alignment = defaultAlignemnt
   peek ptr = do
@@ -186,7 +186,7 @@ instance (Arity (Peano n), Storable a) => Storable (Vec n a) where
     = withForeignPtr fp $ \p ->
       moveArray (castPtr ptr) p (peanoToInt (proxy# @(Peano n)))
 
-instance (Typeable n, Arity (Peano n), Storable a, Data a) => Data (Vec n a) where
+instance (Typeable n, Arity n, Storable a, Data a) => Data (Vec n a) where
   gfoldl       = C.gfoldl
   gunfold      = C.gunfold
   toConstr   _ = con_Vec

--- a/fixed-vector/Data/Vector/Fixed/Unboxed.hs
+++ b/fixed-vector/Data/Vector/Fixed/Unboxed.hs
@@ -46,6 +46,7 @@ import Data.Vector.Fixed (Dim,Vector(..),VectorN,eq,ord,replicate,zipWith,foldl,
                          )
 import Data.Vector.Fixed.Mutable (Mutable, MVector(..), IVector(..), DimM, constructVec, inspectVec, Arity, index)
 import qualified Data.Vector.Fixed.Cont      as C
+import           Data.Vector.Fixed.Cont      (Peano)
 import qualified Data.Vector.Fixed.Primitive as P
 import qualified Data.Vector.Fixed.Internal  as I
 
@@ -67,24 +68,24 @@ type Vec3 = Vec 3
 type Vec4 = Vec 4
 type Vec5 = Vec 5
 
-class (Arity n, IVector (Vec n) a, MVector (MVec n) a) => Unbox n a
+class (Arity (Peano n), IVector (Vec n) a, MVector (MVec n) a) => Unbox n a
 
 
 ----------------------------------------------------------------
 -- Generic instances
 ----------------------------------------------------------------
 
-instance (Arity n, Show a, Unbox n a) => Show (Vec n a) where
+instance (Arity (Peano n), Show a, Unbox n a) => Show (Vec n a) where
   showsPrec = I.showsPrec
 
-instance (Arity n, Unbox n a, NFData a) => NFData (Vec n a) where
+instance (Arity (Peano n), Unbox n a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()
   {-# INLINE rnf #-}
 
 type instance Mutable (Vec n) = MVec n
 
-type instance Dim  (Vec  n) = n
-type instance DimM (MVec n) = n
+type instance Dim  (Vec  n) = Peano n
+type instance DimM (MVec n) = Peano n
 
 instance (Unbox n a) => Vector (Vec n) a where
   construct  = constructVec
@@ -146,9 +147,9 @@ instance (Storable a, Unbox n a) => Storable (Vec n a) where
 data instance MVec n s () = MV_Unit
 data instance Vec  n   () = V_Unit
 
-instance Arity n => Unbox n ()
+instance Arity (Peano n) => Unbox n ()
 
-instance Arity n => MVector (MVec n) () where
+instance Arity (Peano n) => MVector (MVec n) () where
   new          = return MV_Unit
   {-# INLINE new         #-}
   copy _ _     = return ()
@@ -160,7 +161,7 @@ instance Arity n => MVector (MVec n) () where
   unsafeWrite _ _ _ = return ()
   {-# INLINE unsafeWrite #-}
 
-instance Arity n => IVector (Vec n) () where
+instance Arity (Peano n) => IVector (Vec n) () where
   unsafeFreeze _   = return V_Unit
   unsafeThaw   _   = return MV_Unit
   unsafeIndex  _ _ = ()
@@ -176,9 +177,9 @@ instance Arity n => IVector (Vec n) () where
 newtype instance MVec n s Bool = MV_Bool (P.MVec n s Word8)
 newtype instance Vec  n   Bool = V_Bool  (P.Vec  n   Word8)
 
-instance Arity n => Unbox n Bool
+instance Arity (Peano n) => Unbox n Bool
 
-instance Arity n => MVector (MVec n) Bool where
+instance Arity (Peano n) => MVector (MVec n) Bool where
   new          = MV_Bool `liftM` new
   {-# INLINE new         #-}
   copy (MV_Bool v) (MV_Bool w) = copy v w
@@ -190,7 +191,7 @@ instance Arity n => MVector (MVec n) Bool where
   unsafeWrite (MV_Bool v) i b = unsafeWrite v i (fromBool b)
   {-# INLINE unsafeWrite #-}
 
-instance Arity n => IVector (Vec n) Bool where
+instance Arity (Peano n) => IVector (Vec n) Bool where
   unsafeFreeze (MV_Bool v) = V_Bool  `liftM` unsafeFreeze v
   unsafeThaw   (V_Bool  v) = MV_Bool `liftM` unsafeThaw   v
   unsafeIndex  (V_Bool  v) = toBool . unsafeIndex v
@@ -213,7 +214,7 @@ toBool _ = True
 ----------------------------------------------------------------
 -- Primitive wrappers
 #define primMV(ty,con)                              \
-instance Arity n => MVector (MVec n) ty where {     \
+instance Arity (Peano n) => MVector (MVec n) ty where {     \
 ; new = con `liftM` new                             \
 ; copy (con v) (con w) = copy v w                   \
 ; move (con v) (con w) = move v w                   \
@@ -227,7 +228,7 @@ instance Arity n => MVector (MVec n) ty where {     \
 }
 
 #define primIV(ty,con,mcon)                             \
-instance Arity n => IVector (Vec n) ty where {          \
+instance Arity (Peano n) => IVector (Vec n) ty where {          \
 ; unsafeFreeze (mcon v)   = con  `liftM` unsafeFreeze v \
 ; unsafeThaw   (con  v)   = mcon `liftM` unsafeThaw   v \
 ; unsafeIndex  (con  v) i = unsafeIndex v i             \
@@ -239,7 +240,7 @@ instance Arity n => IVector (Vec n) ty where {          \
 #define primWrap(ty,con,mcon) \
 newtype instance MVec n s ty = mcon (P.MVec n s ty) ; \
 newtype instance Vec  n   ty = con  (P.Vec  n   ty) ; \
-instance Arity n => Unbox n ty ; \
+instance Arity (Peano n) => Unbox n ty ; \
 primMV(ty, mcon     )          ; \
 primIV(ty, con, mcon)
 
@@ -270,7 +271,7 @@ newtype instance Vec  n   (Complex a) = V_Complex  (Vec  n   (a,a))
 
 instance (Unbox n a) => Unbox n (Complex a)
 
-instance (Arity n, MVector (MVec n) a) => MVector (MVec n) (Complex a) where
+instance (Arity (Peano n), MVector (MVec n) a) => MVector (MVec n) (Complex a) where
   new = MV_Complex `liftM` new
   {-# INLINE new #-}
   copy (MV_Complex v) (MV_Complex w) = copy v w
@@ -283,7 +284,7 @@ instance (Arity n, MVector (MVec n) a) => MVector (MVec n) (Complex a) where
   unsafeWrite (MV_Complex v) i (a :+ b) = unsafeWrite v i (a,b)
   {-# INLINE unsafeWrite #-}
 
-instance (Arity n, IVector (Vec n) a) => IVector (Vec n) (Complex a) where
+instance (Arity (Peano n), IVector (Vec n) a) => IVector (Vec n) (Complex a) where
   unsafeFreeze (MV_Complex v) = V_Complex `liftM` unsafeFreeze v
   {-# INLINE unsafeFreeze #-}
   unsafeThaw   (V_Complex  v) = MV_Complex `liftM` unsafeThaw v
@@ -301,7 +302,7 @@ data instance Vec  n   (a,b) = V_2  !(Vec  n   a) !(Vec  n   b)
 
 instance (Unbox n a, Unbox n b) => Unbox n (a,b)
 
-instance (Arity n, MVector (MVec n) a, MVector (MVec n) b) => MVector (MVec n) (a,b) where
+instance (Arity (Peano n), MVector (MVec n) a, MVector (MVec n) b) => MVector (MVec n) (a,b) where
   new = do as <- new
            bs <- new
            return $ MV_2 as bs
@@ -318,7 +319,7 @@ instance (Arity n, MVector (MVec n) a, MVector (MVec n) b) => MVector (MVec n) (
   {-# INLINE unsafeWrite #-}
 
 
-instance ( Arity n
+instance ( Arity (Peano n)
          , IVector (Vec n) a, IVector (Vec n) b
          ) => IVector (Vec n) (a,b) where
   unsafeFreeze (MV_2 v w)   = do as <- unsafeFreeze v
@@ -340,7 +341,7 @@ data instance Vec  n   (a,b,c) = V_3  !(Vec  n   a) !(Vec  n   b) !(Vec  n   c)
 
 instance (Unbox n a, Unbox n b, Unbox n c) => Unbox n (a,b,c)
 
-instance (Arity n, MVector (MVec n) a, MVector (MVec n) b, MVector (MVec n) c
+instance (Arity (Peano n), MVector (MVec n) a, MVector (MVec n) b, MVector (MVec n) c
          ) => MVector (MVec n) (a,b,c) where
   new = do as <- new
            bs <- new
@@ -362,7 +363,7 @@ instance (Arity n, MVector (MVec n) a, MVector (MVec n) b, MVector (MVec n) c
     = unsafeWrite v i a >> unsafeWrite w i b >> unsafeWrite u i c
   {-# INLINE unsafeWrite #-}
 
-instance ( Arity n
+instance ( Arity (Peano n)
          , Vector  (Vec n) a, Vector  (Vec n) b, Vector  (Vec n) c
          , IVector (Vec n) a, IVector (Vec n) b, IVector (Vec n) c
          ) => IVector (Vec n) (a,b,c) where
@@ -455,7 +456,7 @@ primNewWrap(Product, V_Product, MV_Product)
 -- Monomorphic newtype wrappers
 
 #define primNewMonoMV(ty,con)                         \
-instance Arity n => MVector (MVec n) ty where {     \
+instance Arity (Peano n) => MVector (MVec n) ty where {     \
 ; new = con `liftM` new                             \
 ; copy (con v) (con w) = copy v w                   \
 ; move (con v) (con w) = move v w                   \
@@ -469,7 +470,7 @@ instance Arity n => MVector (MVec n) ty where {     \
 }
 
 #define primNewMonoIV(ty,con,mcon)                             \
-instance Arity n => IVector (Vec n) ty where {          \
+instance Arity (Peano n) => IVector (Vec n) ty where {          \
 ; unsafeFreeze (mcon v)   = con  `liftM` unsafeFreeze v \
 ; unsafeThaw   (con  v)   = mcon `liftM` unsafeThaw   v \
 ; unsafeIndex  (con  v) i = ty (unsafeIndex v i)             \
@@ -481,7 +482,7 @@ instance Arity n => IVector (Vec n) ty where {          \
 #define primNewMonoWrap(ty,repr,con,mcon) \
 newtype instance MVec n s ty = mcon (MVec n s repr) ; \
 newtype instance Vec  n   ty = con  (Vec  n   repr) ; \
-instance Arity n => Unbox n ty ; \
+instance Arity (Peano n) => Unbox n ty ; \
 primNewMonoMV(ty, mcon     )          ; \
 primNewMonoIV(ty, con, mcon)
 

--- a/fixed-vector/Data/Vector/Fixed/Unboxed.hs
+++ b/fixed-vector/Data/Vector/Fixed/Unboxed.hs
@@ -41,7 +41,7 @@ import GHC.TypeLits
 import Prelude               ( Show(..),Eq(..),Ord(..),Int,Double,Float,Char,Bool(..)
                              , ($),(.),seq)
 
-import Data.Vector.Fixed (Dim,Vector(..),VectorN,eq,ord,replicate,zipWith,foldl,
+import Data.Vector.Fixed (Dim,Vector(..),eq,ord,replicate,zipWith,foldl,
                           defaultSizeOf,defaultAlignemnt,defaultPeek,defaultPoke
                          )
 import Data.Vector.Fixed.Mutable (Mutable, MVector(..), IVector(..), DimM, constructVec, inspectVec, Arity, index)
@@ -94,9 +94,6 @@ instance (Unbox n a) => Vector (Vec n) a where
   {-# INLINE construct  #-}
   {-# INLINE inspect    #-}
   {-# INLINE basicIndex #-}
-
-
-instance (Unbox n a) => VectorN Vec n a
 
 instance (Unbox n a, Eq a) => Eq (Vec n a) where
   (==) = eq

--- a/fixed-vector/Data/Vector/Fixed/Unboxed.hs
+++ b/fixed-vector/Data/Vector/Fixed/Unboxed.hs
@@ -68,17 +68,17 @@ type Vec3 = Vec 3
 type Vec4 = Vec 4
 type Vec5 = Vec 5
 
-class (Arity (Peano n), IVector (Vec n) a, MVector (MVec n) a) => Unbox n a
+class (Arity n, IVector (Vec n) a, MVector (MVec n) a) => Unbox n a
 
 
 ----------------------------------------------------------------
 -- Generic instances
 ----------------------------------------------------------------
 
-instance (Arity (Peano n), Show a, Unbox n a) => Show (Vec n a) where
+instance (Arity n, Show a, Unbox n a) => Show (Vec n a) where
   showsPrec = I.showsPrec
 
-instance (Arity (Peano n), Unbox n a, NFData a) => NFData (Vec n a) where
+instance (Arity n, Unbox n a, NFData a) => NFData (Vec n a) where
   rnf = foldl (\r a -> r `seq` rnf a) ()
   {-# INLINE rnf #-}
 
@@ -147,9 +147,9 @@ instance (Storable a, Unbox n a) => Storable (Vec n a) where
 data instance MVec n s () = MV_Unit
 data instance Vec  n   () = V_Unit
 
-instance Arity (Peano n) => Unbox n ()
+instance Arity n => Unbox n ()
 
-instance Arity (Peano n) => MVector (MVec n) () where
+instance Arity n => MVector (MVec n) () where
   new          = return MV_Unit
   {-# INLINE new         #-}
   copy _ _     = return ()
@@ -161,7 +161,7 @@ instance Arity (Peano n) => MVector (MVec n) () where
   unsafeWrite _ _ _ = return ()
   {-# INLINE unsafeWrite #-}
 
-instance Arity (Peano n) => IVector (Vec n) () where
+instance Arity n => IVector (Vec n) () where
   unsafeFreeze _   = return V_Unit
   unsafeThaw   _   = return MV_Unit
   unsafeIndex  _ _ = ()
@@ -177,9 +177,9 @@ instance Arity (Peano n) => IVector (Vec n) () where
 newtype instance MVec n s Bool = MV_Bool (P.MVec n s Word8)
 newtype instance Vec  n   Bool = V_Bool  (P.Vec  n   Word8)
 
-instance Arity (Peano n) => Unbox n Bool
+instance Arity n => Unbox n Bool
 
-instance Arity (Peano n) => MVector (MVec n) Bool where
+instance Arity n => MVector (MVec n) Bool where
   new          = MV_Bool `liftM` new
   {-# INLINE new         #-}
   copy (MV_Bool v) (MV_Bool w) = copy v w
@@ -191,7 +191,7 @@ instance Arity (Peano n) => MVector (MVec n) Bool where
   unsafeWrite (MV_Bool v) i b = unsafeWrite v i (fromBool b)
   {-# INLINE unsafeWrite #-}
 
-instance Arity (Peano n) => IVector (Vec n) Bool where
+instance Arity n => IVector (Vec n) Bool where
   unsafeFreeze (MV_Bool v) = V_Bool  `liftM` unsafeFreeze v
   unsafeThaw   (V_Bool  v) = MV_Bool `liftM` unsafeThaw   v
   unsafeIndex  (V_Bool  v) = toBool . unsafeIndex v
@@ -214,7 +214,7 @@ toBool _ = True
 ----------------------------------------------------------------
 -- Primitive wrappers
 #define primMV(ty,con)                              \
-instance Arity (Peano n) => MVector (MVec n) ty where {     \
+instance Arity n => MVector (MVec n) ty where {     \
 ; new = con `liftM` new                             \
 ; copy (con v) (con w) = copy v w                   \
 ; move (con v) (con w) = move v w                   \
@@ -228,7 +228,7 @@ instance Arity (Peano n) => MVector (MVec n) ty where {     \
 }
 
 #define primIV(ty,con,mcon)                             \
-instance Arity (Peano n) => IVector (Vec n) ty where {          \
+instance Arity n => IVector (Vec n) ty where {          \
 ; unsafeFreeze (mcon v)   = con  `liftM` unsafeFreeze v \
 ; unsafeThaw   (con  v)   = mcon `liftM` unsafeThaw   v \
 ; unsafeIndex  (con  v) i = unsafeIndex v i             \
@@ -240,7 +240,7 @@ instance Arity (Peano n) => IVector (Vec n) ty where {          \
 #define primWrap(ty,con,mcon) \
 newtype instance MVec n s ty = mcon (P.MVec n s ty) ; \
 newtype instance Vec  n   ty = con  (P.Vec  n   ty) ; \
-instance Arity (Peano n) => Unbox n ty ; \
+instance Arity n => Unbox n ty ; \
 primMV(ty, mcon     )          ; \
 primIV(ty, con, mcon)
 
@@ -271,7 +271,7 @@ newtype instance Vec  n   (Complex a) = V_Complex  (Vec  n   (a,a))
 
 instance (Unbox n a) => Unbox n (Complex a)
 
-instance (Arity (Peano n), MVector (MVec n) a) => MVector (MVec n) (Complex a) where
+instance (Arity n, MVector (MVec n) a) => MVector (MVec n) (Complex a) where
   new = MV_Complex `liftM` new
   {-# INLINE new #-}
   copy (MV_Complex v) (MV_Complex w) = copy v w
@@ -284,7 +284,7 @@ instance (Arity (Peano n), MVector (MVec n) a) => MVector (MVec n) (Complex a) w
   unsafeWrite (MV_Complex v) i (a :+ b) = unsafeWrite v i (a,b)
   {-# INLINE unsafeWrite #-}
 
-instance (Arity (Peano n), IVector (Vec n) a) => IVector (Vec n) (Complex a) where
+instance (Arity n, IVector (Vec n) a) => IVector (Vec n) (Complex a) where
   unsafeFreeze (MV_Complex v) = V_Complex `liftM` unsafeFreeze v
   {-# INLINE unsafeFreeze #-}
   unsafeThaw   (V_Complex  v) = MV_Complex `liftM` unsafeThaw v
@@ -302,7 +302,7 @@ data instance Vec  n   (a,b) = V_2  !(Vec  n   a) !(Vec  n   b)
 
 instance (Unbox n a, Unbox n b) => Unbox n (a,b)
 
-instance (Arity (Peano n), MVector (MVec n) a, MVector (MVec n) b) => MVector (MVec n) (a,b) where
+instance (Arity n, MVector (MVec n) a, MVector (MVec n) b) => MVector (MVec n) (a,b) where
   new = do as <- new
            bs <- new
            return $ MV_2 as bs
@@ -319,7 +319,7 @@ instance (Arity (Peano n), MVector (MVec n) a, MVector (MVec n) b) => MVector (M
   {-# INLINE unsafeWrite #-}
 
 
-instance ( Arity (Peano n)
+instance ( Arity n
          , IVector (Vec n) a, IVector (Vec n) b
          ) => IVector (Vec n) (a,b) where
   unsafeFreeze (MV_2 v w)   = do as <- unsafeFreeze v
@@ -341,7 +341,7 @@ data instance Vec  n   (a,b,c) = V_3  !(Vec  n   a) !(Vec  n   b) !(Vec  n   c)
 
 instance (Unbox n a, Unbox n b, Unbox n c) => Unbox n (a,b,c)
 
-instance (Arity (Peano n), MVector (MVec n) a, MVector (MVec n) b, MVector (MVec n) c
+instance (Arity n, MVector (MVec n) a, MVector (MVec n) b, MVector (MVec n) c
          ) => MVector (MVec n) (a,b,c) where
   new = do as <- new
            bs <- new
@@ -363,7 +363,7 @@ instance (Arity (Peano n), MVector (MVec n) a, MVector (MVec n) b, MVector (MVec
     = unsafeWrite v i a >> unsafeWrite w i b >> unsafeWrite u i c
   {-# INLINE unsafeWrite #-}
 
-instance ( Arity (Peano n)
+instance ( Arity n
          , Vector  (Vec n) a, Vector  (Vec n) b, Vector  (Vec n) c
          , IVector (Vec n) a, IVector (Vec n) b, IVector (Vec n) c
          ) => IVector (Vec n) (a,b,c) where
@@ -456,7 +456,7 @@ primNewWrap(Product, V_Product, MV_Product)
 -- Monomorphic newtype wrappers
 
 #define primNewMonoMV(ty,con)                         \
-instance Arity (Peano n) => MVector (MVec n) ty where {     \
+instance Arity n => MVector (MVec n) ty where {     \
 ; new = con `liftM` new                             \
 ; copy (con v) (con w) = copy v w                   \
 ; move (con v) (con w) = move v w                   \
@@ -470,7 +470,7 @@ instance Arity (Peano n) => MVector (MVec n) ty where {     \
 }
 
 #define primNewMonoIV(ty,con,mcon)                             \
-instance Arity (Peano n) => IVector (Vec n) ty where {          \
+instance Arity n => IVector (Vec n) ty where {          \
 ; unsafeFreeze (mcon v)   = con  `liftM` unsafeFreeze v \
 ; unsafeThaw   (con  v)   = mcon `liftM` unsafeThaw   v \
 ; unsafeIndex  (con  v) i = ty (unsafeIndex v i)             \
@@ -482,7 +482,7 @@ instance Arity (Peano n) => IVector (Vec n) ty where {          \
 #define primNewMonoWrap(ty,repr,con,mcon) \
 newtype instance MVec n s ty = mcon (MVec n s repr) ; \
 newtype instance Vec  n   ty = con  (Vec  n   repr) ; \
-instance Arity (Peano n) => Unbox n ty ; \
+instance Arity n => Unbox n ty ; \
 primNewMonoMV(ty, mcon     )          ; \
 primNewMonoIV(ty, con, mcon)
 

--- a/fixed-vector/fixed-vector.cabal
+++ b/fixed-vector/fixed-vector.cabal
@@ -54,14 +54,13 @@ extra-source-files:
   ChangeLog.md
 
 tested-with:
-    GHC ==8.4.4
-     || ==8.6.5
-     || ==8.8.4
-     || ==8.10.7
+    GHC ==8.10.7
      || ==9.0.1
      || ==9.2.8
      || ==9.4.7
-     || ==9.6.3
+     || ==9.6.6
+     || ==9.8.2
+     || ==9.10.1
 
 source-repository head
   type:     git
@@ -70,7 +69,7 @@ source-repository head
 Library
   Ghc-options:          -Wall -Wno-incomplete-uni-patterns
   Default-Language:     Haskell2010
-  Build-Depends: base      >=4.11 && <5
+  Build-Depends: base      >=4.14 && <5
                , primitive >=0.6.2
                , deepseq
   Exposed-modules:


### PR DESCRIPTION
Since we can't do induction on type level naturals we're working with Peano numbers. Partial rollback of changes in 1.0, namely that `Dim` type family returns Peano number instead of natural which then converted to Peano number simplified code quite a bit. In particular we got rid of constraint

> Peano (n+1) ~ 'S (Peano n)

Which led to absolutely inane type errors like:

> Could not deduce ((F.Dim w0 GHC.TypeNats.+ 1) ~ F.Dim v)

They're difficult to decipher even for library author