### PR TITLE
Optimize implementation of zipWith and map

### DIFF
--- a/fixed-vector/Data/Vector/Fixed/Cont.hs
+++ b/fixed-vector/Data/Vector/Fixed/Cont.hs
@@ -907,19 +907,17 @@ izipWithM_ f xs ys = sequence_ (izipWith f xs ys)
 izipWithF :: (ArityPeano n)
           => (Int -> a -> b -> c) -> Fun n c r -> Fun n a (Fun n b r)
 {-# INLINE izipWithF #-}
-izipWithF f (Fun g0) =
-  fmap (\v -> accum
-              (\(T_izip i (a:as) g) b -> T_izip (i+1) as (g $ f i a b))
-              (\(T_izip _ _      x)   -> x)
-              (T_izip 0 v g0)
-       ) makeList
+izipWithF f (Fun g0)
+  = makeList
+  $ \v -> accum (\(T_izip i (a:as) g) b -> T_izip (i+1) as (g $ f i a b))
+                (\(T_izip _ _      x)   -> x)
+                (T_izip 0 v g0)
 
-
-makeList :: ArityPeano n => Fun n a [a]
+makeList :: ArityPeano n => ([a] -> b) -> Fun n a b
 {-# INLINE makeList #-}
-makeList = accum
+makeList cont = accum
     (\(Const xs) x -> Const (xs . (x:)))
-    (\(Const xs) -> xs [])
+    (\(Const xs) -> cont (xs []))
     (Const id)
 
 data T_izip a c r n = T_izip Int [a] (Fn n c r)

--- a/fixed-vector/Data/Vector/Fixed/Cont.hs
+++ b/fixed-vector/Data/Vector/Fixed/Cont.hs
@@ -208,6 +208,7 @@ instance ArityPeano n => Monad (Fun n a) where
   {-# INLINE return #-}
   {-# INLINE (>>=)  #-}
 
+newtype T_Flip a b n = T_Flip (Fun n a b)
 data T_ap a b c n = T_ap (Fn n a b) (Fn n a c)
 
 
@@ -344,9 +345,6 @@ apGunfold :: Data a
           -> T_gunfold c r a n
 apGunfold f (T_gunfold c) = T_gunfold $ f c
 {-# INLINE apGunfold #-}
-
-
-newtype T_Flip a b n = T_Flip (Fun n a b)
 
 
 

--- a/fixed-vector/Data/Vector/Fixed/Cont.hs
+++ b/fixed-vector/Data/Vector/Fixed/Cont.hs
@@ -677,7 +677,8 @@ mk8 a1 a2 a3 a4 a5 a6 a7 a8 = ContVec $ \(Fun f) -> f a1 a2 a3 a4 a5 a6 a7 a8
 -- | Map over vector. Synonym for 'fmap'
 map :: (ArityPeano n) => (a -> b) -> ContVec n a -> ContVec n b
 {-# INLINE map #-}
-map = imap . const
+map f (ContVec contA) = ContVec $
+  contA . mapF f
 
 -- | Apply function to every element of the vector and its index.
 imap :: (ArityPeano n) => (Int -> a -> b) -> ContVec n a -> ContVec n b
@@ -688,7 +689,9 @@ imap f (ContVec contA) = ContVec $
 -- | Effectful map over vector.
 mapM :: (ArityPeano n, Applicative f) => (a -> f b) -> ContVec n a -> f (ContVec n b)
 {-# INLINE mapM #-}
-mapM = imapM . const
+mapM f v
+ = inspect v
+ $ mapMF f construct
 
 -- | Apply monadic function to every element of the vector and its index.
 imapM :: (ArityPeano n, Applicative f)
@@ -710,25 +713,45 @@ imapM_ :: (ArityPeano n, Applicative f) => (Int -> a -> f b) -> ContVec n a -> f
 imapM_ f = ifoldl (\m i a -> m *> f i a *> pure ()) (pure ())
 
 
+
+mapMF :: (ArityPeano n, Applicative f)
+      => (a -> f b) -> Fun n b r -> Fun n a (f r)
+{-# INLINE mapMF #-}
+mapMF f (Fun funB) =
+  accum (\(T_mapM m) a -> T_mapM (($) <$> m <*> f a))
+        (\(T_mapM m) -> m)
+        (T_mapM (pure funB))
+
 imapMF :: (ArityPeano n, Applicative f)
        => (Int -> a -> f b) -> Fun n b r -> Fun n a (f r)
 {-# INLINE imapMF #-}
 imapMF f (Fun funB) =
-  accum (\(T_mapM i m) a -> T_mapM (i+1) $ ($) <$> m <*> f i a)
-        (\(T_mapM _ m) -> m)
-        (T_mapM 0 (pure funB))
+  accum (\(T_imapM i m) a -> T_imapM (i+1) $ ($) <$> m <*> f i a)
+        (\(T_imapM _ m) -> m)
+        (T_imapM 0 (pure funB))
 
-data T_mapM a m r n = T_mapM Int (m (Fn n a r))
+newtype T_mapM  a m r n = T_mapM      (m (Fn n a r))
+data    T_imapM a m r n = T_imapM Int (m (Fn n a r))
+
+
+mapF :: ArityPeano n
+     => (a -> b) -> Fun n b r -> Fun n a r
+{-# INLINE mapF #-}
+mapF f (Fun funB) =
+  accum (\(T_map g) b -> T_map (g (f b)))
+        (\(T_map r)   -> r)
+        (  T_map funB)
 
 imapF :: ArityPeano n
       => (Int -> a -> b) -> Fun n b r -> Fun n a r
 {-# INLINE imapF #-}
 imapF f (Fun funB) =
-  accum (\(T_map i g) b -> T_map (i+1) (g (f i b)))
-        (\(T_map _ r)   -> r)
-        (  T_map 0 funB)
+  accum (\(T_imap i g) b -> T_imap (i+1) (g (f i b)))
+        (\(T_imap _ r)   -> r)
+        (  T_imap 0 funB)
 
-data T_map a r n = T_map Int (Fn n a r)
+newtype T_map  a r n = T_map      (Fn n a r)
+data    T_imap a r n = T_imap Int (Fn n a r)
 
 -- | Left scan over vector
 scanl :: (ArityPeano n) => (b -> a -> b) -> b -> ContVec n a -> ContVec ('S n) b

--- a/fixed-vector/test/inspect.hs
+++ b/fixed-vector/test/inspect.hs
@@ -38,6 +38,16 @@ fuse_zipWith_self n = F.sum $ F.zipWith (*) u u
   where u :: FU.Vec3 Int
         u = F.replicate n
 
+-- More involved example with zipWith. It stresses optimizer and could be
+-- used as a benchmark for optimization of compilation speed.
+fuse_zipWithParam :: FP.Vec 3 Int -> FP.Vec 3 Int -> FP.Vec 3 Int -> Int
+fuse_zipWithParam v1 v2 v3 = F.sum v12 + F.sum v13 + F.sum v23 where
+  v12 = F.zipWith (*) v1 v2
+  v13 = F.zipWith (*) v1 v3
+  v23 = F.zipWith (*) v2 v3
+
+
+
 main :: IO ()
 main = defaultMain $ testGroup "inspect"
   [ $(inspectObligations [ hasNoTypeClasses
@@ -59,4 +69,7 @@ main = defaultMain $ testGroup "inspect"
                          -- FIXME: Does not fuse when used nonlinearly
                          -- , noArrayAlloc
                          ] 'fuse_zipWith_self)
+  , $(inspectObligations [ hasNoTypeClasses
+                         , noArrayAlloc
+                         ] 'fuse_zipWithParam)
   ]

--- a/fixed-vector/test/inspect.hs
+++ b/fixed-vector/test/inspect.hs
@@ -62,14 +62,21 @@ main = defaultMain $ testGroup "inspect"
   , $(inspectObligations [ hasNoTypeClasses
                          , noArrayAlloc
                          ] 'fuse_mapM_)
-  , $(inspectObligations [ hasNoTypeClasses
-                         , noArrayAlloc
-                         ] 'fuse_zipWith)
-  , $(inspectObligations [ hasNoTypeClasses
-                         -- FIXME: Does not fuse when used nonlinearly
-                         -- , noArrayAlloc
-                         ] 'fuse_zipWith_self)
-  , $(inspectObligations [ hasNoTypeClasses
-                         , noArrayAlloc
-                         ] 'fuse_zipWithParam)
+  , testGroup "zipWith"
+    -- NOTE: zipWith uses lists internally but they should get
+    --       optimized away. Thus check that lists don't occur in core
+    [ $(inspectObligations [ hasNoTypeClasses
+                           , flip hasNoType ''[]
+                           , noArrayAlloc
+                           ] 'fuse_zipWith)
+    , $(inspectObligations [ hasNoTypeClasses
+                           , flip hasNoType ''[]
+                           -- FIXME: Does not fuse when used nonlinearly
+                           -- , noArrayAlloc
+                           ] 'fuse_zipWith_self)
+    , $(inspectObligations [ hasNoTypeClasses
+                           , flip hasNoType ''[]
+                           , noArrayAlloc
+                           ] 'fuse_zipWithParam)
+    ]
   ]


### PR DESCRIPTION
At the moment they are implemented in terms of zipWith and imap. This creates extra work for optimizer which has to strip  unused parameters at each call site. 

Also add another unrelated compile time optimization to zipWith